### PR TITLE
Small fix to makefile uninstall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ install:
 
 uninstall:
 	rm -f $(PREFIX)/bin/jade
-	rm -f $(LIB_PREFIX)/jade.js
+	rm -Rf $(LIB_PREFIX)/jade
 
 test:
 	@./support/expresso/bin/expresso \


### PR DESCRIPTION
The Makefile was recently updated to install the whole /lib/jade folder, so I updated the unistall to remove the folder from .node_libraries. Nothing major.

Thanks!
