### PR TITLE
Fix for colons in attribute names

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -264,13 +264,18 @@ Lexer.prototype = {
                 // Support = and :
                 var colon = pair.indexOf(':'),
                     equal = pair.indexOf('=');
+								// Support colons in attr names for XML namespaces
+								var nextColon = pair.indexOf(':', colon + 1);
+								if(nextColon > -1) {
+									colon = nextColon;
+								}
             
                 // Boolean
                 if (colon < 0 && equal < 0) {
                     var key = pair,
                         val = true;
                 } else {
-                    // Split on first = or :
+                    // Split on = or :
                     var split = equal >= 0
                         ? equal
                         : colon;


### PR DESCRIPTION
I've added support for colons in attribute names. It was a simple addition to lexer.js to check for a colon past the first one found. Seems to work. :)
