### PR TITLE
Synonym for HTML5 doctype that causes self-closing tags (for XHTML5)

### DIFF
--- a/lib/doctypes.js
+++ b/lib/doctypes.js
@@ -7,6 +7,7 @@
 
 module.exports = {
     '5': '<!DOCTYPE html>',
+    'x5': '<!DOCTYPE html>',
     'xml': '<?xml version="1.0" encoding="utf-8" ?>',
     'default': '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">',
     'transitional': '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">',


### PR DESCRIPTION
Allows for self-closing tags with HTML5 doctype.

Sorry for the spam.
