### PR TITLE
Added :plain filter

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -26,6 +26,7 @@
     - :cdata
     - :javascript
     - :coffeescript must have [coffee-script](http://jashkenas.github.com/coffee-script/) installed
+    - :plain
   - [TextMate Bundle](http://github.com/miksago/jade-tmbundle)
   - [Screencasts](http://tjholowaychuk.com/post/1004255394/jade-screencast-template-engine-for-nodejs)
 

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -66,5 +66,12 @@ module.exports = {
         str = str.replace(/\\n/g, '\n');
         var js = require('coffee-script').compile(str).replace(/\n/g, '\\n');
         return '<script type="text/javascript">\\n' + js + '</script>';
+    },
+
+    /**
+     * Pass text unmodified.
+     */
+    plain: function(str) {
+        return str;
     }
 };

--- a/test/filters.test.js
+++ b/test/filters.test.js
@@ -105,6 +105,12 @@ module.exports = {
             '<script type="text/javascript">\n' + js + '\n</script>',
             render(':coffeescript\n  | square = (x) ->\n  |   x * x'));
     },
+
+    'test :plain filter': function(assert){
+        assert.equal(
+            'this is for\na large block of unmodified text\n <b>and markup</b>',
+            render(':plain\n  | this is for\n  | a large block of unmodified text\n  |  <b>and markup</b>'));
+    },
     
     'test parse tree': function(assert){
         var str = [


### PR DESCRIPTION
Based on HAML's :plain filter, passes arbitrary blocks of text through.

Useful for:
- Simple copy/paste of HTML/JS/CSS (e.g. for embedding a 3rd party widget)
- Inlining non-SASSy CSS
- Large blocks of text

Thanks!
Greg
