### PR TITLE
Support for multi-line attributes

### DIFF
--- a/examples/attributes.jade
+++ b/examples/attributes.jade
@@ -6,3 +6,6 @@ div#id.left(class='user user-' + name).container
     input(type: 'text' , name : 'user[name]', value: name)
     input(checked, type: 'checkbox', name: 'user[blocked]')
     input(type='submit', value="Update")
+	input(
+		type='submit',
+		value='Cancel')

--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -256,7 +256,7 @@ Lexer.prototype = {
                 str = this.input.substr(1, index-1);
             this.consume(index + 1);
             var tok = this.tok('attrs', str),
-                attrs = tok.val.split(/ *, *(?=['"\w-]+ *[:=]|[\w-]+ *$)/);
+                attrs = tok.val.split(/ *,\s*(?=['"\w-]+ *[:=]|[\w-]+ *$)/);
             tok.attrs = {};
             for (var i = 0, len = attrs.length; i < len; ++i) {
                 var pair = attrs[i];

--- a/test/jade.test.js
+++ b/test/jade.test.js
@@ -472,6 +472,10 @@ module.exports = {
         assert.equal('<img src="/foo.png" alt="just some foo"/>', render('img(src="/foo.png", alt="just some foo")'));
         assert.equal('<img src="/foo.png" alt="just some foo"/>', render('img(src = "/foo.png", alt = "just some foo")'));
         
+        assert.equal('<img src="/foo.png" alt="just some foo"/>', render('img(src: "/foo.png",\nalt: "just some foo")'), 'Test attr : newline between');
+        assert.equal('<img src="/foo.png" alt="just some foo"/>', render('img(src="/foo.png",\nalt="just some foo")'));
+        assert.equal('<img src="/foo.png" alt="just some foo"/>', render('img(\nsrc: "/foo.png", alt: "just some foo")'), 'Test attr : newline before');        
+
         assert.equal('<p class="foo,bar,baz"></p>', render('p(class="foo,bar,baz")'));
         assert.equal('<a href="http://google.com" title="Some : weird = title"></a>', render('a(href: "http://google.com", title: "Some : weird = title")'));
         assert.equal('<label for="name"></label>', render('label(for="name")'));


### PR DESCRIPTION
Ran the tests as-is, 50 passed.
Added new asserts to 'test attrs', saw attrs test fail.
Changed 'get attrs' to use any whitespace instead of a single space between the comma and next attribute.
All tests pass again.
Added another example to attributes.jade and got the expected output.

Let me know if I missed something.
