### PR TITLE
--stdio, -o foo.coffee

### DIFF
--- a/bin/jade
+++ b/bin/jade
@@ -69,7 +69,14 @@ while (args.length) {
         case '--options':
             var str = args.shift();
             if (str) {
-                options = eval('(' + str + ')');
+                if (str.match(/\.coffee$/)) {
+                  var coffee = fs.readFileSync(str).toString('utf-8');
+                  var js = require('coffee-script').compile(coffee, {bare: true});
+                  options = eval(js);
+                }
+                else {
+                  options = eval('(' + str + ')');
+                }
             } else {
                 sys.error('-o, --options requires a string.');
                 process.exit(1);


### PR DESCRIPTION
Use case: TextMate's live preview, piping the current document through

<pre>
jade -s -o .../stub.coffee
</pre>
