### PR TITLE
fix exception when getAttribute or removeAttribute run into removed attributes

### DIFF
--- a/lib/nodes/tag.js
+++ b/lib/nodes/tag.js
@@ -51,7 +51,7 @@ Tag.prototype.setAttribute = function(name, val){
 
 Tag.prototype.removeAttribute = function(name){
     for (var i = 0, len = this.attrs.length; i < len; ++i) {
-        if (this.attrs[i].name == name) {
+        if (this.attrs[i] && this.attrs[i].name == name) {
             delete this.attrs[i];
         }
     }
@@ -67,7 +67,7 @@ Tag.prototype.removeAttribute = function(name){
 
 Tag.prototype.getAttribute = function(name){
     for (var i = 0, len = this.attrs.length; i < len; ++i) {
-        if (this.attrs[i].name == name) {
+        if (this.attrs[i] && this.attrs[i].name == name) {
             return this.attrs[i].val;
         }
     }

--- a/test/jade.test.js
+++ b/test/jade.test.js
@@ -872,5 +872,15 @@ module.exports = {
         assert.equal(
             "Jade:1\n    1. 'p= asdf'\n\nasdf is not defined",
             err.message);
+    },
+
+    'test null attrs on tag': function(assert){
+        var tag = new jade.nodes.Tag('a'),
+            name = 'href',
+            val = '"/"';
+        tag.setAttribute(name, val)
+        assert.equal(tag.getAttribute(name), val)
+        tag.removeAttribute(name)
+        assert.isUndefined(tag.getAttribute(name))
     }
 };


### PR DESCRIPTION
because removeAttribute only nullifies the entry in the this.attrs array, we may still run into it. this makes getAttribute and setAttribute handle those cases.
