### PR TITLE
Added watch, walk and out options

### DIFF
--- a/bin/jade
+++ b/bin/jade
@@ -6,6 +6,8 @@
 
 var sys = require('sys')
   , fs = require('fs')
+  , resolve = require('path').resolve
+  , basename = require('path').basename
   , jade;
 
 try {
@@ -33,16 +35,43 @@ var pipe;
 var options = {};
 
 /**
+ * Destination dir.
+ */
+
+var dest;
+
+/**
+ * Watcher hash.
+ */
+
+var watchers;
+
+/**
+ * Directory to watch.
+ */
+
+var watchdir;
+
+/**
+ * Walk subdirectories
+ */
+
+var walk = false;
+
+/**
  * Usage information.
  */
 
 var usage = ''
-    + '\x1b[1mUsage\x1b[0m: jade [options] <path ...>\n'
+    + '\x1b[1mUsage\x1b[0m: jade [options] [path ...]\n'
     + '\n'
     + '\x1b[1mOptions:\x1b[0m\n'
     + '  -o, --options STR   JavaScript options object passed\n'
     + '  -p, --pipe          Output to stdout instead of PATH.html\n'
-    + '  -h, --help          Output help information\n';
+    + '  -h, --help          Output help information\n'
+    + '  -w, --watch <dir>   Watch the jade files in <dir>\n'
+    + '  -r, --walk          Walk the subdirectories of the watched <dir>. Only applicable with --watch\n'
+    + '  --out <dir>         Output the compiled html to <dir>\n';
 
 // Parse arguments
 
@@ -70,29 +99,124 @@ while (args.length) {
                 process.exit(1);
             }
             break;
+        case '-w':
+        case '--watch':
+            watchdir = args.shift();
+            watchers = {};
+            break;
+        case '--out':
+            dest = args.shift();
+            break;
+        case '-r':
+            walk = true;
+            break;
         default:
             files.push(arg);
     }
 }
 
+// Watching
+if (watchers && !files.length) {
+    console.log('Watching: ' + resolve(watchdir));
+    fs.readdirSync(watchdir).map(function(filename) {
+        return watchdir + '/' + filename;
+    }).forEach(processFile);
 // Render files
-
-if (files.length) {
+} else if (files.length) {
     files.forEach(function(file){
         jade.renderFile(file, options, function(err, html){
             if (err) throw err;
             if (pipe) {
                 sys.puts(html);
             }  else {
-                file = file.replace(/\.jade$/, '.html');
-                fs.writeFile(file, html, function(err){
-                    if (err) throw err;
-                    sys.error('  create : ' + file);
-                });
+                writeFile(file, html);
             }
         });
     });
 } else {
-    sys.error('files required.');
+    console.log(usage);
     process.exit(1);
+}
+
+/**
+ * Process the given path, compiling the jade files found.
+ * Walk the subdirectories if the -r flag was passed.
+ */
+
+function processFile(path) {
+    fs.lstat(path, function(err, stat) {
+        if (err) throw err;
+        // Found jade file
+        if (stat.isFile() && path.match(/\.jade$/)) {
+            renderJade(path);
+        // Found directory
+        } else if (walk && stat.isDirectory()) {
+            fs.readdir(path, function(err, files) {
+                if (err) throw err;
+                files.map(function(filename) {
+                    return path + '/' + filename;
+                }).forEach(processFile);
+            });
+        }
+    });
+}
+
+/**
+ * Render jade
+ */
+
+function renderJade(jadefile) {
+    jade.renderFile(jadefile, options, function(err, html) {
+        if (err) throw err;
+        writeFile(jadefile, html);
+    });
+}
+
+/**
+ * Write the html output to a file.
+ *
+ * If watching folder ./jades and the destination directory is ./public
+ * a jade file in ./jades/person/index.jade will be written to 
+ * ./public/person/index.html if the ./public/person folder exists.
+ *
+ * If not watching, the html output file is written to the root of the
+ * destination directory, if specified.
+ *
+ * If no destination directory is specified, the output file is written
+ * to the folder containing the jade file.
+ */
+
+function writeFile(jadefilepath, html) {
+    var htmlfilepath = jadefilepath.replace('.jade', '.html');
+    // watchdir and dest specified
+    if (dest && watchdir) {
+        htmlfilepath = htmlfilepath.replace(watchdir, dest);
+    // dest specified, but we are not watching
+    } else if (dest) {
+        htmlfilepath = dest + '/' + basename(htmlfilepath);
+    }
+    fs.writeFile(htmlfilepath, html, function(err) {
+        if (err) throw err;
+        console.log('  \033[90mcompiled\033[0m %s', htmlfilepath);
+        watch(jadefilepath, renderJade);
+    });
+}
+
+/**
+ * Watch the given `file` and invoke `fn` when modified.
+ */
+
+function watch(file, fn) {
+    // not watching
+    if (!watchers) return;
+
+    // already watched
+    if (watchers[file]) return;
+
+    // watch the file itself
+    watchers[file] = true;
+    console.log('  \033[90mwatching\033[0m %s', file);
+    fs.watchFile(file, { interval: 50 }, function(curr, prev){
+        if (curr.mtime > prev.mtime) fn(file);
+    });
 }


### PR DESCRIPTION
Inspired by the ability to watch for changes in stylus, I added watch to jade. Also added the ability to walk/recurse through subdirectories, watching for changed files. Finally added the out option, to specify a destination directory.

I think this could be useful when prototyping html pages.
