### PR TITLE
fixes for IE

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -15,6 +15,11 @@ var nodes = require('./nodes')
   , selfClosing = require('./self-closing')
   , utils = require('./utils');
 
+// fix non-standard js for IE
+if (!String.prototype.trimLeft) {
+  String.prototype.trimLeft = function() {return this.replace(/^\s+/,'');}
+}
+
 /**
  * Initialize `Compiler` with the given `node`.
  *
@@ -91,7 +96,10 @@ Compiler.prototype = {
    */
   
   visitNode: function(node){
-    return this['visit' + node.constructor.name](node);
+    // fix non-standard js for IE
+    var name = node.constructor.name 
+               || node.constructor.toString().match(/function ([^(\s]+)()/)[1];
+    return this['visit' + name](node);
   },
   
   /**

--- a/lib/jade.js
+++ b/lib/jade.js
@@ -188,7 +188,8 @@ function parse(str, options){
         + attrs.toString() + '\n\n'
         + escape.toString()  + '\n\n'
         + 'var buf = [];\n'
-        + 'with (locals || {}) {' + js + '}'
+        // class does not work in IE
+        + 'with (locals || {}) {' + js.replace(/(class:)/g,'"class":') + '}'
         + 'return buf.join("");';
     } catch (err) {
       process.compile(js, filename || 'Jade');


### PR DESCRIPTION
- `class` is a reserved word
- Object.constructor.name is non-standard javascript
- String.trimLeft() is non-standard javascript

works in IE8 now for me (with browserify)
