### PR TITLE
Fix to make Jade more compatible with Backbone.Model

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -77,7 +77,7 @@ Compiler.prototype = {
    */
   
   buffer: function(str, esc){
-    if (esc) str = utils.escape(str);
+    if (esc) str = utils.escapeText(str);
     this.buf.push("buf.push('" + str + "');");
   },
   
@@ -219,7 +219,7 @@ Compiler.prototype = {
   
   visitText: function(text){
     text = utils.text(text.nodes.join(''));
-    if (this.escape) text = escape(text);
+    if (this.escape) text = escapeText(text);
     this.buffer(text);
     this.buffer('\\n');
   },
@@ -233,7 +233,7 @@ Compiler.prototype = {
   
   visitComment: function(comment){
     if (!comment.buffer) return;
-    this.buffer('<!--' + utils.escape(comment.val) + '-->');
+    this.buffer('<!--' + utils.escapeText(comment.val) + '-->');
   },
   
   /**
@@ -274,7 +274,7 @@ Compiler.prototype = {
       var val = code.val.trimLeft();
       this.buf.push('var __val__ = ' + val);
       val = 'null == __val__ ? "" : __val__';
-      if (code.escape) val = 'escape(' + val + ')';
+      if (code.escape) val = 'escapeText(' + val + ')';
       this.buf.push("buf.push(" + val + ");");
     } else {
       this.buf.push(code.val);
@@ -364,7 +364,7 @@ Compiler.prototype = {
  * @api private
  */
 
-function escape(html){
+function escapeText(html){
   return String(html)
     .replace(/&(?!\w+;)/g, '&amp;')
     .replace(/</g, '&lt;')

--- a/lib/jade.js
+++ b/lib/jade.js
@@ -103,7 +103,7 @@ function attrs(obj){
             : buf.push(key + '="' + key + '"');
         }
       } else {
-        buf.push(key + '="' + escape(val) + '"');
+        buf.push(key + '="' + escapeText(val) + '"');
       }
     }
   }
@@ -118,7 +118,7 @@ function attrs(obj){
  * @api private
  */
 
-function escape(html){
+function escapeText(html){
   return String(html)
     .replace(/&(?!\w+;)/g, '&amp;')
     .replace(/</g, '&lt;')
@@ -186,7 +186,7 @@ function parse(str, options){
     try {
       return ''
         + attrs.toString() + '\n\n'
-        + escape.toString()  + '\n\n'
+        + escapeText.toString()  + '\n\n'
         + 'var buf = [];\n'
         + 'with (locals || {}) {' + js + '}'
         + 'return buf.join("");';

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,7 +18,7 @@ var interpolate = exports.interpolate = function(str){
     return escape
       ? str
       : "' + "
-        + ('!' == flag ? '' : 'escape')
+        + ('!' == flag ? '' : 'escapeText')
         + "((interp = " + code.replace(/\\'/g, "'")
         + ") == null ? '' : interp) + '";
   });
@@ -32,7 +32,7 @@ var interpolate = exports.interpolate = function(str){
  * @api private
  */
 
-var escape = exports.escape = function(str) {
+var escapeText = exports.escapeText = function(str) {
   return str.replace(/'/g, "\\'");
 };
 
@@ -45,5 +45,5 @@ var escape = exports.escape = function(str) {
  */
 
 exports.text = function(str){
-  return interpolate(escape(str));
+  return interpolate(escapeText(str));
 };

--- a/test/jade.test.js
+++ b/test/jade.test.js
@@ -931,5 +931,9 @@ module.exports = {
         assert.equal(tag.getAttribute(name), val)
         tag.removeAttribute(name)
         assert.isUndefined(tag.getAttribute(name))
+    },
+
+    'test locals property named escape': function(assert){
+      assert.equal('<p>Jade</p>', render('p #{value}', { locals: { value:"Jade", escape: function(){ return "evil"; } }}));
     }
 };


### PR DESCRIPTION
Hi TJ,

This is a patch to allow a Backbone.js Model instance as the value for Jade's {locals: ..}. Backbone.Model instances have a property called "escape" which clobber's Jade's own escape() function during template execution, in the with(locals){...} block, leading to strange things happening. I've renamed escape() to escapeText(), and added a test.
