### PR TITLE
Added doctype options to the compiler

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -190,7 +190,7 @@ Compiler.prototype = {
     var name = tag.name;
 
     if (!this.hasCompiledTag) {
-      if (!this.hasCompiledDoctype && name === 'html') {
+      if (!this.hasCompiledDoctype && /^html$/i.test(name)) {
         this.visitDoctype();
       }
       this.hasCompiledTag = true;

--- a/test/jade.test.js
+++ b/test/jade.test.js
@@ -39,6 +39,7 @@ module.exports = {
         assert.equal('<!DOCTYPE html>', render('!!! html', { doctype:'xml' }));
         assert.equal('<html></html>', render('html'));
         assert.equal('<!DOCTYPE html><html></html>', render('html', { doctype:'html' }));
+        assert.equal('<!DOCTYPE html><HTML></HTML>', render('HTML', { doctype:'html' }));
     },
     
     'test Buffers': function(assert){


### PR DESCRIPTION
Hello, I needed to force HTML 5 doctypes for all templates being rendered, so I've added some options to the compiler class to do that. The relevant commit message is:

The doctype option adds a default doctype to the compiler which can be
overridden by a doctype declaration in the template. Additionaly, a
forceDoctype option can be set to prevent a template from overriding the
doctype. Assertions have been added to test this behavior.
