### PR TITLE
Optional `self` object to avoid poor `with` performance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ test:
 
 benchmark:
 	@node benchmarks/jade.js \
+	 && node benchmarks/jade-self.js \
 	 && node benchmarks/haml.js \
 	 && node benchmarks/haml2.js \
 	 && node benchmarks/ejs.js

--- a/Readme.md
+++ b/Readme.md
@@ -75,6 +75,7 @@ via npm:
 ### Options
 
  - `scope`     Evaluation scope (`this`)
+ - `self`      Use a `self` namespace to hold the locals. _false by default_
  - `locals`    Local variable object
  - `filename`  Used in exceptions, and required by `cache`
  - `cache`     Cache intermediate JavaScript in memory keyed by `filename`

--- a/benchmarks/example-self.jade
+++ b/benchmarks/example-self.jade
@@ -1,0 +1,6 @@
+ul
+  li!= self.one
+  li!= self.two
+  li!= self.three
+  - each item in self.items
+    li!= item

--- a/benchmarks/jade-self.js
+++ b/benchmarks/jade-self.js
@@ -1,0 +1,43 @@
+
+/**
+ * Module dependencies.
+ */
+
+var bm = require('./common'),
+    jade = require('../lib/jade'),
+    fs = require('fs');
+
+var str = fs.readFileSync(__dirname + '/example-self.jade', 'ascii');
+var fn = jade.compile(str, {self: true});
+var n = bm.times;
+
+bm.start('jade compilation');
+while (n--) {
+  jade.render(str, {
+    filename: 'example-self.jade'
+  , self: true
+  , locals: bm.locals
+  });
+}
+bm.stop();
+
+var n = bm.times;
+
+bm.start('jade execution');
+while (n--) {
+  jade.render(str, {
+    filename: 'example-self.jade'
+  , self: true
+  , cache: true
+  , locals: bm.locals
+  });
+}
+bm.stop();
+
+var n = bm.times;
+
+bm.start('jade compile()');
+while (n--) {
+  fn(bm.locals);
+}
+bm.stop();

--- a/lib/jade.js
+++ b/lib/jade.js
@@ -181,7 +181,7 @@ function parse(str, options){
         + attrs.toString() + '\n\n'
         + escape.toString()  + '\n\n'
         + 'var buf = [];\n'
-        + 'with (locals || {}) {' + js + '}'
+        + (options.self ? 'var self = locals || {}, __ = locals.__;\n' + js : 'with (locals || {}) {' + js + '}')
         + 'return buf.join("");';
     } catch (err) {
       process.compile(js, filename || 'Jade');


### PR DESCRIPTION
I think it could be good to have an optional `self` namespace to hold the locals, so you can avoid `with` poor performance and name collision with helpers.

The default would be using `with` as it is right now.
