### PR TITLE
When compiling, combine sequential "buf.push(str)" lines

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -99,7 +99,17 @@ Compiler.prototype = {
   
   buffer: function(str, esc){
     if (esc) str = utils.escape(str);
+    
+    // If the last thing pushed the to buffer was also a plain string
+    // combine it with the previous str
+    if(this.lastBufferedIndex == this.buf.length){
+      this.buf.pop();
+      str = this.lastBufferedString + str;
+    }
+
     this.buf.push("buf.push('" + str + "');");
+    this.lastBufferedIndex = this.buf.length;
+    this.lastBufferedString = str;
   },
   
   /**


### PR DESCRIPTION
When compiling, combine sequential "buf.push(str)" lines into a single one.

There is not really a noticeable performance increase on small templates, but it makes sense right?
