### PR TITLE
Keep track of indentation while parsing text block

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -294,8 +294,9 @@ Parser.prototype = {
   /**
    * indent (text | newline)* outdent
    */
-   
-  parseTextBlock: function(){
+
+  parseTextBlock: function(textIndent){
+    textIndent = textIndent || "";
     var text = new nodes.Text;
     text.line = this.line();
     this.expect('indent');
@@ -307,13 +308,13 @@ Parser.prototype = {
           break;
         case 'indent':
           text.push('\\n');
-          text.push(this.parseTextBlock().nodes.map(function(text){
-            return '  ' + text;
-          }).join(''));
+          this.parseTextBlock(textIndent + "  ").nodes.forEach(function(node){
+            text.push(node);
+          });
           text.push('\\n');
           break;
         default:
-          text.push(this.advance().val);
+          text.push(textIndent + this.advance().val);
       }
     }
     this.expect('outdent');

--- a/test/filters.test.js
+++ b/test/filters.test.js
@@ -77,21 +77,46 @@ module.exports = {
     },
 
     'test :coffeescript filter': function(assert){
-        var js = [
+        var coffee, js;
+        coffee = [
+            ':coffeescript',
+            '  square = (x) ->',
+            '    x * x'
+        ].join('\n');
+        js = [
+            '<script type="text/javascript">',
             '(function() {',
             '  var square;',
             '  square = function(x) {',
             '    return x * x;',
             '  };',
-            '}).call(this);'
+            '}).call(this);',
+            '</script>'
         ].join('\n');
 
-        assert.equal(
-            '<script type="text/javascript">\n' + js + '\n</script>',
-            render(':coffeescript\n  square = (x) ->\n    x * x'));
+        assert.equal(js, render(coffee));
 
-        assert.equal('<script type="text/javascript">\n(function() {\n  alert(\'test\');\n}).call(this);\n</script>'
-          , render(":coffeescript\n  alert 'test'"));
+        coffee = [
+            ':coffeescript',
+            '  $ ->',
+            '    $("#flash").fadeIn ->',
+            '      console.log("first line")',
+            '      console.log("second line")'
+        ].join('\n');
+        js = [
+            '<script type="text/javascript">',
+            '(function() {',
+            '  $(function() {',
+            '    return $("#flash").fadeIn(function() {',
+            '      console.log("first line");',
+            '      return console.log("second line");',
+            '    });',
+            '  });',
+            '}).call(this);',
+            '</script>'
+        ].join('\n');
+
+        assert.equal(js, render(coffee));
     },
     
     'test parse tree': function(assert){


### PR DESCRIPTION
This solves the problem with the `:coffeescript` filter and with other indentation aware fitlers.

Fixes #197
