### PR TITLE
Corrected attribute style example to match recent changes.

### DIFF
--- a/examples/attributes.jade
+++ b/examples/attributes.jade
@@ -2,7 +2,7 @@ div#id.left(class='user user-' + name).container
   h1.title= name
   form
     //- unbuffered comment :)
-    // Just an example of different attribute styles
-    input(type: 'text' , name : 'user[name]', value: name)
-    input(checked, type: 'checkbox', name: 'user[blocked]')
-    input(type='submit', value="Update")
+    // An example of attributes.
+    input(type='text', name='user[name]', value=name)
+    input(checked, type='checkbox', name='user[blocked]')
+    input(type='submit', value='Update')


### PR DESCRIPTION
The element(attribute: 'value') style does not work anymore. Updated the example accordingly.
