### PR TITLE
Issue with array support on class attributes

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -367,7 +367,13 @@ Compiler.prototype = {
 
     attrs.forEach(function(attr){
       if (attr.name == 'class') {
-        classes.push('(' + attr.val + ')');
+        // Allow array literals as class value
+        if (attr.val.indexOf('[') == 0 &&
+            attr.val.lastIndexOf(']') == attr.val.length -1) {
+          classes.push("'" + JSON.parse(attr.val).join("', '") + "'");
+        } else {
+          classes.push(attr.val);
+        }
       } else {
         var pair = "'" + attr.name + "':(" + attr.val + ')';
         buf.push(pair);
@@ -375,8 +381,8 @@ Compiler.prototype = {
     });
 
     if (classes.length) {
-      classes = classes.join(" + ' ' + ");
-      buf.push("class: " + classes);
+      classes = classes.join(", ");
+      buf.push("class: [" + classes + "]");
     }
 
     buf = buf.join(', ').replace('class:', '"class":');

--- a/lib/jade.js
+++ b/lib/jade.js
@@ -94,7 +94,12 @@ function attrs(obj){
             ? buf.push(key)
             : buf.push(key + '="' + key + '"');
         }
-      } else if ('class' == key && Array.isArray(val)) {
+      } else if ('class' == key && Array.isArray(val) && val.length) {
+        for (var ai = 0, alen = val.length; ai < alen; ++ai) {
+          if (Array.isArray(val[ai])) {
+            val[ai] = val[ai].join(' ');
+          }
+        }
         buf.push(key + '="' + escape(val.join(' ')) + '"');
       } else {
         buf.push(key + '="' + escape(val) + '"');

--- a/test/jade.test.js
+++ b/test/jade.test.js
@@ -447,6 +447,12 @@ module.exports = {
 
     'test class attr array': function(assert){
         assert.equal('<body class="foo bar baz"></body>', render('body(class=["foo", "bar", "baz"])'));
+
+        assert.equal('<body class="foo bar baz"></body>', render('body.foo(class=["bar", "baz"])'));
+        assert.equal('<body class="foo bar baz"></body>', render('body.foo.bar(class=["baz"])'));
+
+        assert.equal('<body class="foo bar baz"></body>', render('body.foo(class=classes)', { locals: { classes: ['bar', 'baz'] }}));
+        assert.equal('<body class="foo bar baz"></body>', render('body.foo.bar(class=classes)', { locals: { classes: ['baz'] }}));
     },
 
     'test attr interpolation': function(assert){


### PR DESCRIPTION
If a jade tag has specified one or more classes, the array support for class attributes fails.

```
p.foo(class=['bar', 'baz'])
```

compiled to

```
<p class="foo bar,baz"></p>
```

instead of

```
<p class="foo bar baz"></p>
```
