### PR TITLE
Colons in attributes

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -214,7 +214,7 @@ Lexer.prototype = {
    */
   
   id: function() {
-    return this.scan(/^#([\w-]+)/, 'id');
+    return this.scan(/^#([\w-:]+)/, 'id');
   },
   
   /**


### PR DESCRIPTION
Colons (`:`) are a valid character in the HTML `id` attribute:

http://www.w3.org/TR/html401/types.html#type-name

and would be useful for this:

http://csswizardry.com/2011/06/namespacing-fragment-identifiers/

Although periods (`.`) are also allowed, I didn't add those in as well since it would complicate issues with `.` being used as a class identifier in Jade.
