### PR TITLE
Markdown filter: failing existing test + code block newline problem

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -258,8 +258,10 @@ Parser.prototype = {
       , attrs = this.accept('attrs');
 
     this.lexer.pipeless = true;
+    this.lexer.inFilter = true;
     block = this.parseTextBlock();
     this.lexer.pipeless = false;
+    this.lexer.inFilter = false;
 
     var node = new nodes.Filter(tok.val, block, attrs && attrs.attrs);
     node.line = this.line();
@@ -332,7 +334,7 @@ Parser.prototype = {
    */
 
   parseTextBlock: function(){
-    var text = new nodes.Text;
+    var text = new nodes.Text, pendingIndent = false;
     text.line = this.line();
     var spaces = this.expect('indent').val;
     if (null == this._spaces) this._spaces = spaces;
@@ -348,7 +350,10 @@ Parser.prototype = {
           this.parseTextBlock().nodes.forEach(function(node){
             text.push(node);
           });
-          text.push('\\n');
+          if(!this.lexer.inFilter)
+            text.push('\\n');
+          else
+            pendingIndent = true;
           break;
         default:
           text.push(indent + this.advance().val);
@@ -357,6 +362,8 @@ Parser.prototype = {
 
     if (spaces == this._spaces) this._spaces = null;
     this.expect('outdent');
+    if(pendingIndent && 'outdent' != this.peek().type)
+      text.push('\\n');
     return text;
   },
 

--- a/test/filters.test.js
+++ b/test/filters.test.js
@@ -58,6 +58,17 @@ module.exports = {
             render(':markdown\n  #foo\n  - bar\n  - baz\n').replace(/\n/g, ''))
     },
     
+    'test :markdown filter with preformatted code': function(assert){
+        assert.includes(
+          render([':markdown',
+                  '  x',
+                  '      {',
+                  '        x',
+                  '          x',
+                  '      }.'].join('\n')),
+          '<pre><code>{\n  x\n    x\n}.\n</code></pre>')
+    },
+    
     'test :stylus filter': function(assert){
         assert.equal(
             '<style>body {\n  color: #c00;\n}\n</style>',


### PR DESCRIPTION
The Markdown filter test fails with Discount 2.1.0 because of newline differences.
Since it is difficult (and not functionally interesting) to try to reconcile the newline differences across different Markdown engines, I suggest to make the test newline-invariant.

Below is the failing test.

```
filters.test.js test :markdown filter: AssertionError: "<h1>foo</h1>\n\n<ul>\n<li>bar</li>\n<li>baz</li>\n</ul>\n" == "<h1>foo</h1>\n\n<ul><li>bar</li><li>baz</li></ul>"
    at /Users/ruben/Desktop/jade/test/filters.test.js:56:16
    at next (/Users/ruben/Library/Tools/node/lib/node/.npm/expresso/0.6.4/package/bin/expresso:769:25)
    at runSuite (/Users/ruben/Library/Tools/node/lib/node/.npm/expresso/0.6.4/package/bin/expresso:787:6)
    at check (/Users/ruben/Library/Tools/node/lib/node/.npm/expresso/0.6.4/package/bin/expresso:648:16)
    at runFile (/Users/ruben/Library/Tools/node/lib/node/.npm/expresso/0.6.4/package/bin/expresso:652:10)
    at Array.forEach (native)
    at runFiles (/Users/ruben/Library/Tools/node/lib/node/.npm/expresso/0.6.4/package/bin/expresso:629:13)
    at run (/Users/ruben/Library/Tools/node/lib/node/.npm/expresso/0.6.4/package/bin/expresso:598:5)
    at Object.<anonymous> (/Users/ruben/Library/Tools/node/lib/node/.npm/expresso/0.6.4/package/bin/expresso:851:13)
    at Module._compile (module.js:423:26)


   Failures: 1
```
