### PR TITLE
Made easier to include exact raw html such as HTML5 boilerplate through add :raw filter.

### DIFF
--- a/lib/filters.js
+++ b/lib/filters.js
@@ -14,6 +14,13 @@ module.exports = {
     cdata: function(str){
         return '<![CDATA[\\n' + str + '\\n]]>';
     },
+    /**
+     * Do nothing: useful for implementing stuff like HTML5 Boilerplate
+     */
+
+    raw : function(str) {
+    	return str;
+    },
     
     /**
      * Wrap text with script and CDATA tags.


### PR DESCRIPTION
Hi, very small change but I've found it useful when I've got a lot of raw HTML to cut and paste.
