### PR TITLE
All script tags are now textOnly.

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -31,7 +31,7 @@ var Parser = exports = module.exports = function Parser(str, filename, options){
  * Tags that may not contain tags.
  */
 
-var textOnly = exports.textOnly = ['code', 'script', 'textarea', 'style', 'title'];
+var textOnly = exports.textOnly = ['code', 'textarea', 'style', 'title'];
 
 /**
  * Parser prototype.
@@ -457,15 +457,14 @@ Parser.prototype = {
     // newline*
     while ('newline' == this.peek().type) this.advance();
 
-    tag.textOnly = tag.textOnly || ~textOnly.indexOf(tag.name);
-
     // script special-case
     if ('script' == tag.name) {
       var type = tag.getAttribute('type');
-      if (!tag.textOnly && type && 'text/javascript' != type.replace(/^['"]|['"]$/g, '')) {
-        tag.textOnly = false;
-      }
+      tag.textOnly = tag.textOnly || !type 
+                     || 'text/javascript' == type.replace(/^['"]|['"]$/g, '');
     }
+
+    tag.textOnly = tag.textOnly || ~textOnly.indexOf(tag.name);
 
     // block?
     if ('indent' == this.peek().type) {

--- a/test/jade.test.js
+++ b/test/jade.test.js
@@ -702,6 +702,24 @@ module.exports = {
     assert.equal(html, render(str));
   },
 
+  'test non javascript script without trailing .': function(assert){
+    var str = [
+     'script(type="text/x-template")',
+     '  .foo',
+     '    h1 Hello'
+    ].join('\n');
+
+    var html = [
+        '<script type="text/x-template">',
+        '<div class="foo">',
+        '<h1>Hello</h1>',
+        '</div>',
+        '</script>'
+    ].join('');
+
+    assert.equal(html, render(str));
+  },
+
   'test - each': function(assert){
       // Array
       var str = [


### PR DESCRIPTION
The most recent changes seem to have permitted text parsing of script tags ending in a dot at the expense of allowing jade to parse a script tag under any other circumstance.  I think jade's flexibility to handle client side templates is a great feature.  I think the effect of this commit is what was originally intended anyway.  Thanks.
