### PR TITLE
Fixes:

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -799,7 +799,7 @@ HTML = $(JADE:.jade=.html)
 all: $(HTML)
 	
 %.html: %.jade
-	jade < $< --path $<> > $@
+	jade < $< --path $< > $@
 
 clean:
 	rm -f $(HTML)


### PR DESCRIPTION
/bin/sh: Syntax error: redirection unexpected

On OS X and Ubuntu Natty
