### PR TITLE
client-side jade incorrectly work on "old" browsers

### DIFF
--- a/runtime.js
+++ b/runtime.js
@@ -25,7 +25,7 @@ if (!Object.keys) {
     var arr = [];
     for (var key in obj) {
       if (obj.hasOwnProperty(key)) {
-        arr.push(obj);
+        arr.push(key);
       }
     }
     return arr;


### PR DESCRIPTION
it don't generate any attributes when started in Firefox 3 and other browsers where Object.keys() function is not defened. See my issue #1 for details.
