### PR TITLE
Include files with a .jade extension as jade files

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -431,14 +431,19 @@ Parser.prototype = {
     if (!this.filename)
       throw new Error('the "filename" option is required to use includes');
 
+    // no extension
+    if (basename(path).indexOf('.') === -1) {
+      path += '.jade';
+    }
+
     // non-jade
-    if (~basename(path).indexOf('.')) {
+    if (path.substr(-5) !== '.jade') {
       var path = join(dir, path)
         , str = fs.readFileSync(path, 'utf8');
       return new nodes.Literal(str);
     }
 
-    var path = join(dir, path + '.jade')
+    var path = join(dir, path)
       , str = fs.readFileSync(path, 'utf8')
      , parser = new Parser(str, path, this.options);
 


### PR DESCRIPTION
The include statement only parses files as Jade files when they are specified without extension. If the template’s file name has another extension (»graph.svg.jade«), there is no way to get this template parsed as Jade.

The proposed patch parses .jade files as Jade.
