### PR TITLE
Fixing "SyntaxError: Parse error" in QTWebkit

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -1,4 +1,3 @@
-
 /*!
  * Jade - Lexer
  * Copyright(c) 2010 TJ Holowaychuk <tj@vision-media.ca>
@@ -244,7 +243,7 @@ Lexer.prototype = {
    * Extends.
    */
   
-  extends: function() {
+  'extends': function() {
     return this.scan(/^extends +([^\n]+)/, 'extends');
   },
 
@@ -342,7 +341,7 @@ Lexer.prototype = {
    * While.
    */
   
-  while: function() {
+  'while': function() {
     var captures;
     if (captures = /^while +([^\n]+)/.exec(this.input)) {
       this.consume(captures[0].length);
@@ -634,13 +633,13 @@ Lexer.prototype = {
       || this.case()
       || this.when()
       || this.default()
-      || this.extends()
+      || this['extends']()
       || this.block()
       || this.include()
       || this.mixin()
       || this.conditional()
       || this.each()
-      || this.while()
+      || this.['while']()
       || this.assignment()
       || this.tag()
       || this.filter()


### PR DESCRIPTION
Loading Jade in QTWebkit would fail with "SyntaxError: Parse error" on each of the lines I changed, ostensibly because it considers 'extends' and 'while' to be keywords (which they are) and wouldn't allow them in object literals unquoted or as property accessors (is that what they are called?).

Just check out the diff; you'll see what I mean.
