### PR TITLE
Multiline JavaScript support

### DIFF
--- a/jade.js
+++ b/jade.js
@@ -810,42 +810,6 @@ function parse(str, options){
     runtime.rethrow(err, parser.filename, parser.lexer.lineno);
   }
 }
-
-/**
- * Hack to one-line javascript embedded in jade
- *
- * @param {String} str
- * @return {String}
- */
-
-var multilineCodeHack = function (str) {
-  var code = false,
-    lines = str.split('\n'),
-    out = '',
-    indent = 0,
-    captures, line;
-
-  for (var i = 0; i < lines.length; i += 1) {
-    line = lines[i];
-    if (code) {
-      captures = /^([ \t]*)/.exec(line);
-      if (captures[1].length > indent) {
-        out += line;
-      } else {
-        code = false;
-        out += '\n' + line + '\n';
-      }
-    } else if (captures = /^([\w]*)-(.*)$/.exec(line)) {
-      code = true;
-      indent = captures[1].length;
-      out += line;
-    } else {
-      out += line + '\n';
-    }
-  }
-  return out;
-};
-
  
 /**
  * Compile a `Function` representation of the given jade `str`.
@@ -869,8 +833,6 @@ exports.compile = function(str, options){
       ? JSON.stringify(options.filename)
       : 'undefined'
     , fn;
-
-  str = multilineCodeHack(str);
 
   if (options.compileDebug !== false) {
     fn = [

--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -5,6 +5,56 @@
  * MIT Licensed
  */
 
+
+ /**
+  * Hack to one-line javascript embedded in jade
+  *
+  * @param {String} str
+  * @return {String}
+  */
+
+function multilineCodeHack(str){
+  var code = false
+    , lines = str.split('\n')
+    , out = ''
+    , indent = 0
+    , captures
+    , lineFix = 0
+    , line
+    , lineNum = 0;
+
+  for (var i = 0; i < lines.length; ++i) {
+    line = lines[i];
+    if (code) {
+      captures = /^(\s*)--$/.exec(line);
+      if (captures && captures[1].length === indent) {
+        code = false;
+        out += '\n';
+        for (var j = 0; j < lineFix; j += 1) {
+          out += '#-\n';
+        }
+        lineFix = 0;
+      } else {
+        out += line;
+        lineFix++;
+      }
+    } else if (captures = /^(\s*)--$/.exec(line)) {
+      code = true;
+      lineNum = i + 1;
+      indent = captures[1].length;
+      out += '- ';
+    } else {
+      out += line + '\n';
+    }
+  }
+  
+  if (code) {
+    throw 'Multiline block not closed on line ' + lineNum;
+  }
+  
+  return out;
+};
+
 /**
  * Initialize `Lexer` with the given `str`.
  *
@@ -19,7 +69,7 @@
 
 var Lexer = module.exports = function Lexer(str, options) {
   options = options || {};
-  this.input = str.replace(/\r\n|\r/g, '\n');
+  this.input = multilineCodeHack(str.replace(/\r\n|\r/g, '\n'));
   this.colons = options.colons;
   this.deferredTokens = [];
   this.lastIndents = 0;


### PR DESCRIPTION
I'm a bit new at this Github business, so forgive me if I'm overstepping any boundaries. I'm a big fan of jade, and very grateful for your work. :)

This is a quick and dirty hack to support multiline JavaScript. It preprocesses the input, and rewrites multiline JS to be on a single line before lexing.

```
--
var ob = {
    prop: 'val'
}
--
h1 My Awesome Page
```

becomes

```
- var ob = {    prop: 'val'}
-#
-#
-#
h1 My Awesome Page
```

The inserted comment lines are there to preserve line numbers errors and warnings normally issued by jade's lex and compile. An exception is thrown if there is no closing "--" with matching indentation. Other than that, line comments ("//") will probably break this, and any indentation within the block is accepted.

I feel a bit guilty mucking up your otherwise nicely written lexer, but hopefully this at least gets the ball rolling on adding multiline support. I'm also not sure if "--" is the "correct" symbol to mark multiline JavaScript. I'd love to hear your thoughts on it.

Thanks!
