### PR TITLE
Add link in README to jade-mode for Emacs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -32,6 +32,7 @@
     - :markdown must have [markdown-js](http://github.com/evilstreak/markdown-js) installed or [node-discount](http://github.com/visionmedia/node-discount)
     - :cdata
     - :coffeescript must have [coffee-script](http://jashkenas.github.com/coffee-script/) installed
+  - [Emacs Mode](https://github.com/brianc/jade-mode)
   - [Vim Syntax](https://github.com/digitaltoad/vim-jade)
   - [TextMate Bundle](http://github.com/miksago/jade-tmbundle)
   - [Screencasts](http://tjholowaychuk.com/post/1004255394/jade-screencast-template-engine-for-nodejs)


### PR DESCRIPTION
Hello, just adding a link for Emacs users so they will quickly know where to find a good jade-mode.

Keep up the good work,

—Travis Jeffery
