### PR TITLE
Discard the BOM of UTF-8 jade file created by windows editors

### DIFF
--- a/lib/jade.js
+++ b/lib/jade.js
@@ -1,4 +1,3 @@
-
 /*!
  * Jade
  * Copyright(c) 2010 TJ Holowaychuk <tj@vision-media.ca>
@@ -134,6 +133,11 @@ function parse(str, options){
  */
 
 exports.compile = function(str, options){
+  str = (function trimBOM(s) {    // trim the BOM 
+    var index = s.substr(0, Math.min(10, s.length)).indexOf('!!!');   // find the '!!!' start chars within the first 10 chars
+	  return index > 0 ? s.substr(index) : s;
+  })(str);
+  
   var options = options || {}
     , client = options.client
     , filename = options.filename


### PR DESCRIPTION
Many people create jade files with editors on windows(like i do), but the utf-8 byte order marks (BOM) added by these editors cause crashes when jade rendering docment types.

As noticed in the issuse #235:

https://github.com/visionmedia/jade/issues/235

I provide this part of code to remove the unnecessary characters before !!!, if no !!! provided, the code will do nothing.
