### PR TITLE
Test for conditional in included block issue

### DIFF
--- a/test/fixtures/scripts-conditional.jade
+++ b/test/fixtures/scripts-conditional.jade
@@ -1,0 +1,2 @@
+- if (false)
+  script(src='/jquery.js')

--- a/test/jade.test.js
+++ b/test/jade.test.js
@@ -968,6 +968,18 @@ module.exports = {
       , render(str, { filename: __dirname + '/jade.test.js' }));
   },
 
+  'test include block containing a conditional': function(){
+    var str = [
+        'html',
+        '  head',
+        '    include fixtures/scripts-conditional',
+        '      scripts(src="/app.js")',
+    ].join('\n');
+
+    assert.equal('<html><head><scripts src=\"/app.js\"></scripts></head></html>'
+      , render(str, { filename: __dirname + '/jade.test.js' }));
+  },
+
   'test .render(str, fn)': function(){
     jade.render('p foo bar', function(err, str){
       assert.ok(!err);


### PR DESCRIPTION
Found another issue - if the included file ends inside a conditional block, the condition applies to included block content.  This test demonstrates this, by including a script with an `- if (false)` block and showing that the content inside the block include is also not rendered.

I'll look into a fix - although again, hopefully you can spot it first :)
