### PR TITLE
Block include appends to closed block

### DIFF
--- a/test/fixtures/scripts-conditional.jade
+++ b/test/fixtures/scripts-conditional.jade
@@ -1,2 +1,3 @@
-- if (false)
+if false
   script(src='/jquery.js')
+script(src='/caustic.js')

--- a/test/jade.test.js
+++ b/test/jade.test.js
@@ -973,10 +973,10 @@ module.exports = {
         'html',
         '  head',
         '    include fixtures/scripts-conditional',
-        '      scripts(src="/app.js")',
+        '      script(src="/app.js")',
     ].join('\n');
 
-    assert.equal('<html><head><scripts src=\"/app.js\"></scripts></head></html>'
+    assert.equal('<html><head><script src=\"caustic.js\"></script><script src=\"/app.js\"></script></head></html>'
       , render(str, { filename: __dirname + '/jade.test.js' }));
   },
 


### PR DESCRIPTION
This is a replacement for #453, containing a test that demonstrates a block include adding content to a block that is not the last statement and has thus already been closed.
