### PR TITLE
Tag#attrs : array - performance drawback refactor offer

### DIFF
--- a/lib/nodes/tag.js
+++ b/lib/nodes/tag.js
@@ -1,4 +1,3 @@
-
 /*!
  * Jade - nodes - Tag
  * Copyright(c) 2010 TJ Holowaychuk <tj@vision-media.ca>
@@ -23,6 +22,7 @@ var Node = require('./node'),
 var Tag = module.exports = function Tag(name, block) {
   this.name = name;
   this.attrs = [];
+  this.attrs.ix = {}; //map of indexes by attr name
   this.block = block || new Block;
 };
 
@@ -44,7 +44,10 @@ Tag.prototype.__proto__ = Node.prototype;
  */
 
 Tag.prototype.setAttribute = function(name, val){
-  this.attrs.push({ name: name, val: val });
+  ( this.attrs.ix[name]          //exists?
+    ? this.attrs.ix[name]        // - use it
+    : this.attrs.ix[name] = []   // orelse - init & use returned value of assignment
+  ).push( this.attrs.push({ name: name, val: val }) - 1 );
   return this;
 };
 
@@ -52,15 +55,18 @@ Tag.prototype.setAttribute = function(name, val){
  * Remove attribute `name` when present.
  *
  * @param {String} name
+ * @return {Tag} for chaining
  * @api public
  */
 
 Tag.prototype.removeAttribute = function(name){
-  for (var i = 0, len = this.attrs.length; i < len; ++i) {
-    if (this.attrs[i] && this.attrs[i].name == name) {
-      delete this.attrs[i];
-    }
-  }
+  var arix = this.attrs.ix[name]; 
+  if (!arix) return;
+  delete this.attrs.ix[name];
+  arix.forEach(function(ix){
+    delete this.attrs[ix]; 
+  });
+  return this;
 };
 
 /**
@@ -72,9 +78,14 @@ Tag.prototype.removeAttribute = function(name){
  */
 
 Tag.prototype.getAttribute = function(name){
-  for (var i = 0, len = this.attrs.length; i < len; ++i) {
-    if (this.attrs[i] && this.attrs[i].name == name) {
-      return this.attrs[i].val;
-    }
-  }
+  var attr = this.attrs
+    , arix = attr.ix[name]
+    ;
+  //TODO: how should we handle a case an attribute is pushed several times?
+  if (arix) 
+      return attr[ arix[0] ]; 
+      //Alternatives - return a single value or array of values? 
+      // return (arix = arix.map(function(ix){ return attr[ix]})).lenhth > 1 ? arix : arix[0];
+      //                                    or CSV as arix.join(",") ??
+      // return arix.map(function(ix){ return attr[ix]}).join(",")
 };


### PR DESCRIPTION
First - I want to say I love what you're doing there. Anyway, I was reading for my own pleasure and then I saw this performance drawback of looping all attributes to remove and to find, where there are simple tools to do better.

I figured that you're using an array because in some stage of the program you need to loop it using an Array API, and secondly because you might want to allow same attribute to be added several times (if both assumptions are wrong - then array is a bad choice, you just as well use an object ).
So, what I propose here is an index map, where every key is the attribute name, and every value is an array of the indexes this attribute appears.
The current API returns the first occurency of the attribute  in the tag - which leaves open for cases the attribute is pushed several times...

Good luck :)
