### PR TITLE
Throw error with line number for bad attribute syntax

### DIFF
--- a/lib/jade.js
+++ b/lib/jade.js
@@ -161,9 +161,12 @@ exports.compile = function(str, options){
     fn = new Function('locals, attrs, escape, rethrow', fn);
   } catch (err) {
     if (err instanceof SyntaxError && options.compileDebug !== false) {
-      fn = fn.replace(/^buf\.push\((.*?)\);$/gmi, function (str, p1) {
-        return "buf.push(eval('" + p1.replace(/'/g, "\\'") + "'));";
-      });
+      var replacer = function (str, p1, p2, p3) {
+        return p1 + "eval('"
+            + p2.replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/\n/g, '\\n')
+            + "');" + p3;
+      };
+      fn = fn.replace(/(__jade\.(?:.*?);\n)([\s\S]+?)(\n__jade\.(?:.*?);)/g, replacer);
       fn = new Function('locals, attrs, escape, rethrow', fn);
     } else {
       throw err;


### PR DESCRIPTION
Addresses issue #252.

Uses try/catch in jade.js to avoid always compiling with eval.
