### PR TITLE
As-is filter

### DIFF
--- a/lib/filters.js
+++ b/lib/filters.js
@@ -8,6 +8,14 @@
 module.exports = {
   
   /**
+   * Output block as-is.
+   */
+  
+  asis: function(str){
+    return str;
+  },
+  
+  /**
    * Wrap text with CDATA block.
    */
   


### PR DESCRIPTION
I know this is stupidly simple, but hear me out.

My app uses jade templates on the server side to generate pages, and underscore templates client-side to generate backbone views. It turns out though that getting the templates to work properly in jade is really ugly.

I tried stuff like this, which kills readability;

```
script(type='text/javascript')
  templates.post = [
    '<% if (a) { %>'
    , ' some <%= stuff %> goes here'
    , '<% } %>'
  ].join('')
```

and this, which kills indentation depth;

```
script(type='text/template', id='post-template')
  | <% if (a) { %>
  | some <% stuff %> goes here
  | <% } %>
```

But both are rather fragile and inelegant. Thus :asis was born;

```
script(type='text/template', id='update-template')
  :asis
    <% if (a) { %>
      some <% stuff %> goes here
    <% } %>
```
