### PR TITLE
HTML5: omit quotes from attributes empty, or not containing spaces

### DIFF
--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -1,4 +1,3 @@
-
 /*!
  * Jade - runtime
  * Copyright(c) 2010 TJ Holowaychuk <tj@vision-media.ca>
@@ -59,7 +58,11 @@ exports.attrs = function attrs(obj){
       } else if ('class' == key && Array.isArray(val)) {
         buf.push(key + '="' + exports.escape(val.join(' ')) + '"');
       } else {
-        buf.push(key + '="' + exports.escape(val) + '"');
+        val.length > 0
+          ? val.search(/\s/) == -1
+            ? buf.push(key + '=' + exports.escape(val))
+            : buf.push(key + '="' + exports.escape(val) + '"')
+          : buf.push(key);
       }
     }
   }


### PR DESCRIPTION
Minor edit to exports.attrs related to HTML5, to omit quotes from attributes which are empty or do not contain spaces. 

The change would mean that this Jade

```
.many.classes#idpresent(manyvalues='1 2', novalue='', onevalue='1')
```

...would output

```
<div id=idpresent manyvalues="1 2" novalue onevalue=1 class="many classes"></div>
```

...where before it output

```
<div id="idpresent" manyvalues="1 2" novalue="" onevalue="1" class="many classes"></div> 
```

Although debatably more performant, I'm sure this isn't to everyone's taste. 
If accepted at all, you may decide to make this configurable.

Thanks, hope you don't mind me sticking my nose in.

Jamie / [@GotNoSugarBaby](https://twitter.com/#!/GotNoSugarBaby)
