### PR TITLE
Allow inlineTags to be modified

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -1,4 +1,3 @@
-
 /*!
  * Jade - Compiler
  * Copyright(c) 2010 TJ Holowaychuk <tj@vision-media.ca>
@@ -55,6 +54,10 @@ var Compiler = module.exports = function Compiler(node, options) {
   this.pp = options.pretty || false;
   this.debug = false !== options.compileDebug;
   this.indents = 0;
+  
+  // Append inlineTags to this to make it accessible from require('jade').Compiler.inlineTags
+  this.inlineTags = inlineTags;
+  
   if (options.doctype) this.setDoctype(options.doctype);
 };
 


### PR DESCRIPTION
By appending the inlineTags array to the Compiler, the list of tags to not 'prettify' can be altered programmaticly from the Jade.Compiler object. This is useful for white-space sensitive HTML tags such as textarea and pre.
