### PR TITLE
Fix .npmignore to actually be useful

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,12 @@
-test
-support
-benchmarks
-examples
+.npmignore
+.gitmodules
+.travis.yml
+
+History.md
+Readme.md
+Makefile
+
+test/
+support/
+benchmarks/
+examples/


### PR DESCRIPTION
npm has a bug where it fails to ignore directories if they don't have the
trailing slash. Also add Readme, History, Makefile and other misc files to
.npmignore.
