### PR TITLE
Adding the ability to support optional properties.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -234,6 +234,16 @@ will result in a literal script tag:
     - var html = "<script></script>"
     | !{html}
 
+In the case of a property that may or may not exist, we can use the ${optionalproperty} variant.  The following
+will result in <p></p>, if the property "doh" cannot be found.
+    p ${doh}
+
+Additionally, if you want to specify a default option for a non-existant property, you can do the following:
+    p #{doh|"Undefined"}
+    p !{doh|"<span>Ruh Roh!</span>"}
+
+In the above case, the line p #{doh|"Undefined"} and p ${doh|"Undefined"} would be equivalent.
+
 Nested tags that also contain text can optionally use a text block:
 
     label

--- a/jade.js
+++ b/jade.js
@@ -3096,13 +3096,20 @@ require.register("utils.js", function(module, exports, require){
  */
 
 var interpolate = exports.interpolate = function(str){
-  return str.replace(/(\\)?([#!]){(.*?)}/g, function(str, escape, flag, code){
-    return escape
-      ? str
-      : "' + "
-        + ('!' == flag ? '' : 'escape')
-        + "((interp = " + code.replace(/\\'/g, "'")
-        + ") == null ? '' : interp) + '";
+  return str.replace(/(\\)?([#!$]){(.*?)}/g, function(str, escape, flag, code){
+    function unescaped() {
+        var split = code.replace(/\\'/g, "'").split('|', 2);
+        code = code[0];
+        var defaultVal = split.length == 2 ? split[1] : ('$' == flag ? '""' : undefined);
+        var opt = (defaultVal !== undefined
+            ? '("undefined" === typeof ' + code + ' ? ' + defaultVal + ' : ' + code + ')' 
+            : code);
+        return "' + "
+            + ('!' == flag ? '' : 'escape')
+            + "((interp = " + opt + ") == null ? '' : interp) + '";
+    }
+
+    return escape ? str : unescaped();
   });
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -14,13 +14,20 @@
  */
 
 var interpolate = exports.interpolate = function(str){
-  return str.replace(/(\\)?([#!]){(.*?)}/g, function(str, escape, flag, code){
-    return escape
-      ? str
-      : "' + "
-        + ('!' == flag ? '' : 'escape')
-        + "((interp = " + code.replace(/\\'/g, "'")
-        + ") == null ? '' : interp) + '";
+  return str.replace(/(\\)?([#!$]){(.*?)}/g, function(str, escape, flag, code){
+    function unescaped() {
+        var split = code.replace(/\\'/g, "'").split('|', 2);
+        code = code[0];
+        var defaultVal = split.length == 2 ? split[1] : ('$' == flag ? '""' : undefined);
+        var opt = (defaultVal !== undefined
+            ? '("undefined" === typeof ' + code + ' ? ' + defaultVal + ' : ' + code + ')' 
+            : code);
+        return "' + "
+            + ('!' == flag ? '' : 'escape')
+            + "((interp = " + opt + ") == null ? '' : interp) + '";
+    }
+
+    return escape ? str : unescaped();
   });
 };
 


### PR DESCRIPTION
I love this library.  

Right now, the render function stops if a property isn't found (e.g. #{foodoesntexist}).  This is by design, I'm sure, but it would be nice to be able to specify a different behavior, so I added a few ways:
# {foodoesntexist|"Hello"} will return hello

${foodoesntexist} will return blank and is the same as writing #{foodoesntexist|}
!{foodoesntexist|"<b>Hi</b>"} will return the bold tag

If the pipe is not specified, then the template behaves as it currently does without my changes.

I didn't know how to run your make file or tests, though.  :(

Thanks,
Chris
