### PR TITLE
pre generating static attributes

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -461,6 +461,19 @@ Compiler.prototype = {
    */
   
   visitAttributes: function(attrs){
+
+    var isConstant = true;
+    attrs.forEach(function(attr) {
+      if(!checkConstant(attr.val)) {
+        isConstant = false;
+      }
+    });
+
+    if(isConstant) {
+      this.buf.push("buf.push('" + staticAttrs(this.terse, attrs) + "')");
+      return;
+    }
+
     var buf = []
       , classes = [];
 
@@ -500,4 +513,64 @@ function escape(html){
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;');
+}
+
+/**
+ * check val is constant string
+ * @param {String} val
+ * @api public
+ */
+function checkConstant(val) {
+  return /^('[^']*'|"[^"]*"|\d*|0x[\da-f]*|true|false|undefined|null)$/i.test(val);
+}
+
+/**
+ * strip constant string to constant val
+ */
+function stripConstant(val) {
+  if(val === 'true') return true;
+  if(val === 'false') return false;
+  if(val === 'undefined') return undefined;
+  if(val === 'null') return null;
+  if(/^\d+$/.test(val)) return parseInt(val);
+  if(/^0x[\da-f]*/i.test(val)) return parseInt(val.substring(2), 16);
+  var match = /^'([^']*)'$/.exec(val) || /^"([^"]*)"$/.exec(val);
+  if(match) {
+    return match[1]
+  }
+  throw new Error('"' + val + '" is not constant');
+}
+
+/**
+ * Render the given attributes object.
+ *
+ * @param {Object} obj
+ * @return {String}
+ * @api private
+ */
+
+function staticAttrs(terse, attrs){
+  var buf = [];
+
+  if (attrs.length) {
+    buf.push('');
+    attrs.forEach(function(attr) {
+      var key = attr.name
+        , val = attr.val;
+      val = stripConstant(val);
+
+      if ('boolean' == typeof val || null == val) {
+        if (val) {
+          terse
+          ? buf.push(key)
+          : buf.push(key + '="' + key + '"');
+        }
+      } else if ('class' == key && Array.isArray(val)) {
+        buf.push(key + '="' + escape(val.join(' ')) + '"');
+      } else {
+        buf.push(key + '="' + escape(val) + '"');
+      }
+    });
+  }
+  return buf.join(' ');
 }


### PR DESCRIPTION
After compile, there are many static attributes is no need to generat at runtime, we can generate at compile time.

before:

```
buf.push('><link');                                                                                 
buf.push(attrs({ terse: true, 'href':("/stylesheets/style.css"), 'rel':("stylesheet") }));          
buf.push('><link');                                                                                 
buf.push(attrs({ terse: true, 'href':('/javascripts/jquery-notify/ui.notify.css'), 'rel':('stylesheet') }));
```

now:

```
buf.push('><link');                                                                                 
buf.push(' href="/stylesheets/style.css" rel="stylesheet"')                                         
buf.push('><link');                                                                                 
buf.push(' href="/javascripts/jquery-notify/ui.notify.css" rel="stylesheet"')   
```
