### PR TITLE
push to the internal buffer?

### DIFF
--- a/lib/jade.js
+++ b/lib/jade.js
@@ -106,7 +106,7 @@ function parse(str, options){
     }
 
     return ''
-      + 'var buf = [];\n'
+      + 'var buf = arguments.callee.buf = [];\n'
       + (options.self
         ? 'var self = locals || {};\n' + js
         : 'with (locals || {}) {\n' + js + '\n}\n')


### PR DESCRIPTION
... currently possible?

If not, the change I appended exposes the internal buffer (in a way how [jade-ext](https://github.com/1602/jade-ext) did it). 

Use Cases:

e.g.

``` javascript
- formFor(user, function() {
  p
    - this.label('name')
    - this.textField('name')
- })
```

... or as discussed at #136
