### PR TITLE
Added code highlighting to bash and jade

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -87,23 +87,31 @@
 
 via npm:
 
-    $ npm install jade
-    $ man jade
+```bash
+$ npm install jade
+$ man jade
+```
 
 <a name="a4"/>
 ## Browser Support
 
  To compile jade to a single file compatible for client-side use simply execute:
 
-    $ make jade.js
+```bash
+$ make jade.js
+```
 
  Alternatively, if uglifyjs is installed via npm (`npm install uglify-js`) you may execute the following which will create both files. However each release builds these for you.
 
-    $ make jade.min.js
+```bash
+$ make jade.min.js
+```
 
   By default Jade instruments templates with line number statements such as `__.lineno = 3` for debugging purposes. When used in a browser it's useful to minimize this boiler plate, you can do so by passing the option `{ compileDebug: false }`. The following template
 
-    p Hello #{name}
+```jade
+p Hello #{name}
+```
 
  Can then be as small as the following generated function:
 
@@ -166,32 +174,42 @@ fn(locals);
 
 A tag is simply a leading word:
 
-    html
+```jade
+html
+```
 
 for example is converted to `<html></html>`
 
 tags can also have ids:
 
-    div#container
+```jade
+div#container
+```
 
 which would render `<div id="container"></div>`
 
 how about some classes?
 
-    div.user-details
+```jade
+div.user-details
+```
 
 renders `<div class="user-details"></div>`
 
 multiple classes? _and_ an id? sure:
 
-    div#foo.bar.baz
+```jade
+div#foo.bar.baz
+```
 
 renders `<div id="foo" class="bar baz"></div>`
 
 div div div sure is annoying, how about:
 
-    #foo
-    .bar
+```jade
+#foo
+.bar
+```
 
 which is syntactic sugar for what we have already been doing, and outputs:
 
@@ -204,71 +222,89 @@ which is syntactic sugar for what we have already been doing, and outputs:
 
 Simply place some content after the tag:
 
-    p wahoo!
+```jade
+p wahoo!
+```
 
 renders `<p>wahoo!</p>`.
 
 well cool, but how about large bodies of text:
 
-    p
-      | foo bar baz
-      | rawr rawr
-      | super cool
-      | go jade go
+```jade
+p
+  | foo bar baz
+  | rawr rawr
+  | super cool
+  | go jade go
+```
 
 renders `<p>foo bar baz rawr.....</p>`
 
 interpolation? yup! both types of text can utilize interpolation,
 if we passed `{ name: 'tj', email: 'tj@vision-media.ca' }` to the compiled function we can do the following:
 
-    #user #{name} &lt;#{email}&gt;
+```jade
+#user #{name} &lt;#{email}&gt;
+```
 
 outputs `<div id="user">tj &lt;tj@vision-media.ca&gt;</div>`
 
 Actually want `#{}` for some reason? escape it!
 
-    p \#{something}
+```jade
+p \#{something}
+```
 
 now we have `<p>#{something}</p>`
 
 We can also utilize the unescaped variant `!{html}`, so the following
 will result in a literal script tag:
 
-    - var html = "<script></script>"
-    | !{html}
+```jade
+- var html = "<script></script>"
+| !{html}
+```
 
 Nested tags that also contain text can optionally use a text block:
 
-    label
-      | Username:
-      input(name='user[name]')
+```jade
+label
+  | Username:
+  input(name='user[name]')
+```
 
 or immediate tag text:
 
-    label Username:
-      input(name='user[name]')
+```jade
+label Username:
+  input(name='user[name]')
+```
 
 Tags that accept _only_ text such as `script` and `style` do not
 need the leading `|` character, for example:
 
-    html
-      head
-        title Example
-        script
-          if (foo) {
-            bar();
-          } else {
-            baz();
-          }
+```jade
+html
+  head
+    title Example
+    script
+      if (foo) {
+        bar();
+      } else {
+        baz();
+      }
+```
 
 Once again as an alternative, we may use a trailing `.` to indicate a text block, for example:
 
-    p.
-      foo asdf
-      asdf
-       asdfasdfaf
-       asdf
-      asd.
+```jade
+p.
+  foo asdf
+  asdf
+   asdfasdfaf
+   asdf
+  asd.
+```
 
 outputs:
 
@@ -283,7 +319,9 @@ asd.
 
 This however differs from a trailing `.` followed by a space, which although is ignored by the Jade parser, tells Jade that this period is a literal:
 
-    p .
+```jade
+p .
+```
 
 outputs:
 
@@ -299,8 +337,10 @@ It should be noted that text blocks should be doubled escaped.  For example if y
 
 use:
 
-    p.
-      foo\\bar
+```jade
+p.
+  foo\\bar
+```
 
 <a name="a6-4"/>
 ### Comments
@@ -308,9 +348,11 @@ use:
 Single line comments currently look the same as JavaScript comments,
 aka `//` and must be placed on their own line:
 
-    // just some paragraphs
-    p foo
-    p bar
+```jade
+// just some paragraphs
+p foo
+p bar
+```
 
 would output
 
@@ -322,9 +364,11 @@ would output
 
 Jade also supports unbuffered comments, by simply adding a hyphen:
 
-    //- will not output within markup
-    p foo
-    p bar
+```jade
+//- will not output within markup
+p foo
+p bar
+```
 
 outputting
 
@@ -338,10 +382,12 @@ outputting
 
  A block comment is legal as well:
 
-    body
-      //
-        #content
-          h1 Example
+```jade
+body
+  //
+    #content
+      h1 Example
+```
 
 outputting
 
@@ -357,9 +403,11 @@ outputting
 
 Jade supports conditional-comments as well, for example:
 
-    head
-      //if lt IE 8
-        script(src='/ie-sucks.js')
+```jade
+head
+  //if lt IE 8
+    script(src='/ie-sucks.js')
+```
 
 outputs:
 
@@ -376,13 +424,15 @@ outputs:
 
  Jade supports nesting to define the tags in a natural way:
 
-    ul
-      li.first
-        a(href='#') foo
-      li
-        a(href='#') bar
-      li.last
-        a(href='#') baz
+```jade
+ul
+  li.first
+    a(href='#') foo
+  li
+    a(href='#') bar
+  li.last
+    a(href='#') baz
+```
 
 <a name="a6-7"/>
 ### Block Expansion
@@ -390,96 +440,124 @@ outputs:
  Block expansion allows you to create terse single-line nested tags,
  the following example is equivalent to the nesting example above.
 
-    ul
-      li.first: a(href='#') foo
-      li: a(href='#') bar
-      li.last: a(href='#') baz
+```jade
+ul
+  li.first: a(href='#') foo
+  li: a(href='#') bar
+  li.last: a(href='#') baz
+```
 
 <a name="a6-8"/>
 ### Case
 
  The case statement takes the following form:
 
-    html
-      body
-        friends = 10
-        case friends
-          when 0
-            p you have no friends
-          when 1
-            p you have a friend
-          default
-            p you have #{friends} friends
+```jade
+html
+  body
+    friends = 10
+    case friends
+      when 0
+        p you have no friends
+      when 1
+        p you have a friend
+      default
+        p you have #{friends} friends
+```
 
  Block expansion may also be used:
 
-    friends = 5
+```jade
+friends = 5
 
-    html
-      body
-        case friends
-          when 0: p you have no friends
-          when 1: p you have a friend
-          default: p you have #{friends} friends
+html
+  body
+    case friends
+      when 0: p you have no friends
+      when 1: p you have a friend
+      default: p you have #{friends} friends
+```
 
 <a name="a6-9"/>
 ### Attributes
 
 Jade currently supports `(` and `)` as attribute delimiters.
 
-    a(href='/login', title='View login page') Login
+```jade
+a(href='/login', title='View login page') Login
+```
 
 When a value is `undefined` or `null` the attribute is _not_ added,
 so this is fine, it will not compile `something="null"`.
 
-    div(something=null)
+```jade
+div(something=null)
+```
 
 Boolean attributes are also supported:
 
-    input(type="checkbox", checked)
+```jade
+input(type="checkbox", checked)
+```
 
 Boolean attributes with code will only output the attribute when `true`:
 
-    input(type="checkbox", checked=someValue)
+```jade
+input(type="checkbox", checked=someValue)
+```
 
 Multiple lines work too:
 
-    input(type='checkbox',
-      name='agreement',
-      checked)
+```jade
+input(type='checkbox',
+  name='agreement',
+  checked)
+```
 
 Multiple lines without the comma work fine:
 
-    input(type='checkbox'
-      name='agreement'
-      checked)
+```jade
+input(type='checkbox'
+  name='agreement'
+  checked)
+```
 
 Funky whitespace? fine:
 
-    input(
-      type='checkbox'
-      name='agreement'
-      checked)
+```jade
+input(
+  type='checkbox'
+  name='agreement'
+  checked)
+```
 
 Colons work:
 
-    rss(xmlns:atom="atom")
+```jade
+rss(xmlns:atom="atom")
+```
 
 Suppose we have the `user` local `{ id: 12, name: 'tobi' }`
 and we wish to create an anchor tag with `href` pointing to "/user/12"
 we could use regular javascript concatenation:
 
-    a(href='/user/' + user.id)= user.name
+```jade
+a(href='/user/' + user.id)= user.name
+```
 
 or we could use jade's interpolation, which I added because everyone
 using Ruby or CoffeeScript seems to think this is legal js..:
 
-    a(href='/user/#{user.id}')= user.name
+```jade
+a(href='/user/#{user.id}')= user.name
+```
 
 The `class` attribute is special-cased when an array is given,
 allowing you to pass an array such as `bodyClasses = ['user', 'authenticated']` directly:
 
-    body(class=bodyClasses)
+```jade
+body(class=bodyClasses)
+```
 
 <a name="a6-10"/>
 ### HTML
@@ -487,18 +565,22 @@ allowing you to pass an array such as `bodyClasses = ['user', 'authenticated']` 
  Inline html is fine, we can use the pipe syntax to
  write arbitrary text, in this case some html:
 
-    html
-      body
-        | <h1>Title</h1>
-        | <p>foo bar baz</p>
+```jade
+html
+  body
+    | <h1>Title</h1>
+    | <p>foo bar baz</p>
+```
 
  Or we can use the trailing `.` to indicate to Jade that we
  only want text in this block, allowing us to omit the pipes:
 
-    html
-      body.
-        <h1>Title</h1>
-        <p>foo bar baz</p>
+```jade
+html
+  body.
+    <h1>Title</h1>
+    <p>foo bar baz</p>
+```
 
  Both of these examples yield the same result:
 
@@ -511,39 +593,53 @@ allowing you to pass an array such as `bodyClasses = ['user', 'authenticated']` 
  The same rule applies for anywhere you can have text
  in jade, raw html is fine:
 
-    html
-      body
-        h1 User <em>#{name}</em>
+```jade
+html
+  body
+    h1 User <em>#{name}</em>
+```
 
 <a name="a6-11"/>
 ### Doctypes
 
 To add a doctype simply use `!!!`, or `doctype` followed by an optional value:
 
-    !!!
+```jade
+!!!
+```
 
 Will output the _transitional_ doctype, however:
 
-    !!! 5
+```jade
+!!! 5
+```
 
 or
 
-    !!! html
+```jade
+!!! html
+```
 
 or
 
-    doctype html
+```jade
+doctype html
+```
 
 Will output the _html 5_ doctype.
 
 Doctypes are case-insensitive, so the following are equivalent:
 
-    doctype Basic
-    doctype basic
+```jade
+doctype Basic
+doctype basic
+```
 
 it's also possible to simply pass a doctype literal:
 
-    doctype html PUBLIC "-//W3C//DTD XHTML Basic 1.1//EN
+```jade
+doctype html PUBLIC "-//W3C//DTD XHTML Basic 1.1//EN
+```
 
 yielding:
 
@@ -580,10 +676,12 @@ Filters are prefixed with `:`, for example `:markdown` and
 pass the following block of text to an arbitrary function for processing. View the _features_
 at the top of this document for available filters.
 
-    body
-      :markdown
-        Woah! jade _and_ markdown, very **cool**
-        we can even link to [stuff](http://google.com)
+```jade
+body
+  :markdown
+    Woah! jade _and_ markdown, very **cool**
+    we can even link to [stuff](http://google.com)
+```
 
 Renders:
 
@@ -597,62 +695,78 @@ Renders:
 Jade currently supports three classifications of executable code. The first
 is prefixed by `-`, and is not buffered:
 
-    - var foo = 'bar';
+```jade
+- var foo = 'bar';
+```
 
 This can be used for conditionals, or iteration:
 
-    - for (var key in obj)
-      p= obj[key]
+```jade
+- for (var key in obj)
+  p= obj[key]
+```
 
 Due to Jade's buffering techniques the following is valid as well:
 
-    - if (foo)
-      ul
-        li yay
-        li foo
-        li worked
-    - else
-      p oh no! didnt work
+```jade
+- if (foo)
+  ul
+    li yay
+    li foo
+    li worked
+- else
+  p oh no! didnt work
+```
 
 Hell, even verbose iteration:
 
-    - if (items.length)
-      ul
-        - items.forEach(function(item){
-          li= item
-        - })
+```jade
+- if (items.length)
+  ul
+    - items.forEach(function(item){
+      li= item
+    - })
+```
 
 Anything you want!
 
 Next up we have _escaped_ buffered code, which is used to
 buffer a return value, which is prefixed by `=`:
 
-    - var foo = 'bar'
-    = foo
-    h1= foo
+```jade
+- var foo = 'bar'
+= foo
+h1= foo
+```
 
 Which outputs `bar<h1>bar</h1>`. Code buffered by `=` is escaped
 by default for security, however to output unescaped return values
 you may use `!=`:
 
-    p!= aVarContainingMoreHTML
+```jade
+p!= aVarContainingMoreHTML
+```
 
  Jade also has designer-friendly variants, making the literal JavaScript
  more expressive and declarative. For example the following assignments
  are equivalent, and the expression is still regular javascript:
 
-    - var foo = 'foo ' + 'bar'
-    foo = 'foo ' + 'bar'
+```jade
+- var foo = 'foo ' + 'bar'
+foo = 'foo ' + 'bar'
+```
 
   Likewise Jade has first-class `if`, `else if`, `else`, `until`, `while`, `unless` among others, however you must remember that the expressions are still regular javascript:
 
-    if foo == 'bar'
-      ul
-        li yay
-        li foo
-        li worked
-    else
-      p oh no! didnt work
+```jade
+if foo == 'bar'
+  ul
+    li yay
+    li foo
+    li worked
+else
+  p oh no! didnt work
+```
 
 <a name="a9"/>
 ## Iteration
@@ -661,13 +775,17 @@ you may use `!=`:
  constructs that allow you to create more designer-friendly templates,
  one of these constructs is `each`, taking the form:
 
-    each VAL[, KEY] in OBJ
+```jade
+each VAL[, KEY] in OBJ
+```
 
 An example iterating over an array:
 
-    - var items = ["one", "two", "three"]
-    each item in items
-      li= item
+```jade
+- var items = ["one", "two", "three"]
+each item in items
+  li= item
+```
 
 outputs:
 
@@ -679,9 +797,11 @@ outputs:
 
 iterating an array with index:
 
-    items = ["one", "two", "three"]
-    each item, i in items
-      li #{item}: #{i}
+```jade
+items = ["one", "two", "three"]
+each item, i in items
+  li #{item}: #{i}
+```
 
 outputs:
 
@@ -693,9 +813,11 @@ outputs:
 
 iterating an object's keys and values:
 
-    obj = { foo: 'bar' }
-    each val, key in obj
-      li #{key}: #{val}
+```jade
+obj = { foo: 'bar' }
+each val, key in obj
+  li #{key}: #{val}
+```
 
 would output `<li>foo: bar</li>`
 
@@ -704,15 +826,19 @@ JavaScript loops such as `users.forEach(function(user){`,
 so lexical scope and nesting applies as it would with regular
 JavaScript:
 
-    each user in users
-      each role in user.roles
-        li= role
+```jade
+each user in users
+  each role in user.roles
+    li= role
+```
 
  You may also use `for` if you prefer:
 
-    for user in users
-      for role in user.roles
-        li= role
+```jade
+for user in users
+  for role in user.roles
+    li= role
+```
 
 <a name="a10"/>
 ## Conditionals
@@ -721,27 +847,33 @@ JavaScript:
  however allow you to ditch parenthesis to become more designer friendly,
  however keep in mind the expression given is _regular_ JavaScript:
 
-    for user in users
-      if user.role == 'admin'
-        p #{user.name} is an admin
-      else
-        p= user.name
+```jade
+for user in users
+  if user.role == 'admin'
+    p #{user.name} is an admin
+  else
+    p= user.name
+```
 
  is equivalent to the following using vanilla JavaScript literals:
 
-    for user in users
-      - if (user.role == 'admin')
-        p #{user.name} is an admin
-      - else
-        p= user.name
+```jade
+for user in users
+  - if (user.role == 'admin')
+    p #{user.name} is an admin
+  - else
+    p= user.name
+```
 
   Jade also provides have `unless` which is equivalent to `if (!(expr))`:
 
-    for user in users
-      unless user.isAnonymous
-        p
-          | Click to view
-          a(href='/users/' + user.id)= user.name
+```jade
+for user in users
+  unless user.isAnonymous
+    p
+      | Click to view
+      a(href='/users/' + user.id)= user.name
+```
 
 <a name="a11"/>
 ## Template inheritance
@@ -750,70 +882,82 @@ JavaScript:
 
   Jade blocks can provide default content if desired, however optional as shown below by `block scripts`, `block content`, and `block foot`.
 
-    html
-      head
-        h1 My Site - #{title}
-        block scripts
-          script(src='/jquery.js')
-      body
-        block content
-        block foot
-          #footer
-            p some footer content
+```jade
+html
+  head
+    h1 My Site - #{title}
+    block scripts
+      script(src='/jquery.js')
+  body
+    block content
+    block foot
+      #footer
+        p some footer content
+```
 
   Now to extend the layout, simply create a new file and use the `extends` directive as shown below, giving the path (with or without the .jade extension). You may now define one or more blocks that will override the parent block content, note that here the `foot` block is _not_ redefined and will output "some footer content".
 
-    extends layout
+```jade
+extends layout
 
-    block scripts
-      script(src='/jquery.js')
-      script(src='/pets.js')
+block scripts
+  script(src='/jquery.js')
+  script(src='/pets.js')
 
-    block content
-      h1= title
-      each pet in pets
-        include pet
+block content
+  h1= title
+  each pet in pets
+    include pet
+```
 
   It's also possible to override a block to provide additional blocks, as shown in the following example where `content` now exposes a `sidebar` and `primary` block for overriding, or the child template could override `content` all together.
 
-    extends regular-layout
+```jade
+extends regular-layout
 
-    block content
-      .sidebar
-        block sidebar
-          p nothing
-      .primary
-        block primary
-          p nothing
+block content
+  .sidebar
+    block sidebar
+      p nothing
+  .primary
+    block primary
+      p nothing
+```
 
 <a name="a12"/>
 ## Block append / prepend
 
  Jade allows you to _replace_ (default), _prepend_, or _append_ blocks. Suppose for example you have default scripts in a "head" block that you wish to utilize on _every_ page, you might do this:
 
-    html
-      head
-        block head
-          script(src='/vendor/jquery.js')
-          script(src='/vendor/caustic.js')
-        body
-          block content
+```jade
+html
+  head
+    block head
+      script(src='/vendor/jquery.js')
+      script(src='/vendor/caustic.js')
+    body
+      block content
+```
 
  Now suppose you have a page of your application for a JavaScript game, you want some game related scripts as well as these defaults, you can simply `append` the block:
 
-    include layout
+```jade
+include layout
 
-    block append head
-      script(src='/vendor/three.js')
-      script(src='/game.js')
+block append head
+  script(src='/vendor/three.js')
+  script(src='/game.js')
+```
 
   When using `block append` or `block prepend` the `block` is optional:
 
-    include layout
+```jade
+include layout
 
-    append head
-      script(src='/vendor/three.js')
-      script(src='/game.js')
+append head
+  script(src='/vendor/three.js')
+  script(src='/game.js')
+```
 
 <a name="a13"/>
 ## Includes
@@ -828,12 +972,14 @@ JavaScript:
 
 and the following _layout.jade_:
 
-    html
-      include includes/head
-      body
-        h1 My Site
-        p Welcome to my super amazing site.
-        include includes/foot
+```jade
+html
+  include includes/head
+  body
+    h1 My Site
+    p Welcome to my super amazing site.
+    include includes/foot
+```
 
 both includes _includes/head_ and _includes/foot_ are
 read relative to the `filename` option given to _layout.jade_,
@@ -861,46 +1007,58 @@ which should be an absolute path to this file, however Express does this for you
  assume that the file is Jade source and will include it as
  a literal:
 
-    html
-      body
-        include content.html
+```jade
+html
+  body
+    include content.html
+```
 
   Include directives may also accept a block, in which case the
   the given block will be appended to the _last_ block defined
   in the file. For example if `head.jade` contains:
 
-    head
-      script(src='/jquery.js')
+```jade
+head
+  script(src='/jquery.js')
+```
 
  We may append values by providing a block to `include head`
  as shown below, adding the two scripts.
 
-    html
-      include head
-        script(src='/foo.js')
-        script(src='/bar.js')
-      body
-        h1 test
+```jade
+html
+  include head
+    script(src='/foo.js')
+    script(src='/bar.js')
+  body
+    h1 test
+```
 
  You may also `yield` within an included template, allowing you to explicitly mark where the block given to `include` will be placed. Suppose for example you wish to prepend scripts rather than append, you might do the following:
 
-    head
-      yield
-      script(src='/jquery.js')
-      script(src='/jquery.ui.js')
+```jade
+head
+  yield
+  script(src='/jquery.js')
+  script(src='/jquery.ui.js')
+```
 
  Since included Jade is parsed and literally merges the AST, lexically scoped variables function as if the included Jade was written right in the same file. This means `include` may be used as sort of partial, for example support we have `user.jade` which utilizes a `user` variable.
 
-    h1= user.name
-    p= user.occupation
+```jade
+h1= user.name
+p= user.occupation
+```
 
 We could then simply `include user` while iterating users, and since the `user` variable is already defined within the loop the included template will have access to it.
 
-    users = [{ name: 'Tobi', occupation: 'Ferret' }]
+```jade
+users = [{ name: 'Tobi', occupation: 'Ferret' }]
 
-    each user in users
-      .user
-        include user
+each user in users
+  .user
+    include user
+```
 
 yielding:
 
@@ -913,10 +1071,12 @@ yielding:
 
 If we wanted to expose a different variable name as `user` since `user.jade` references that name, we could simply define a new variable as shown here with `user = person`:
 
-    each person in users
-      .user
-        user = person
-        include user
+```jade
+each person in users
+  .user
+    user = person
+    include user
+```
 
 <a name="a14"/>
 ## Mixins
@@ -925,29 +1085,35 @@ If we wanted to expose a different variable name as `user` since `user.jade` ref
  the compiled template that Jade constructs. Mixins may
  take arguments, though not required:
 
-    mixin list
-      ul
-        li foo
-        li bar
-        li baz
+```jade
+mixin list
+  ul
+    li foo
+    li bar
+    li baz
+```
 
   Utilizing a mixin without args looks similar, just without a block:
 
-    h2 Groceries
-    mixin list
+```jade
+h2 Groceries
+mixin list
+```
 
   Mixins may take one or more arguments as well, the arguments
   are regular javascripts expressions, so for example the following:
 
-    mixin pets(pets)
-      ul.pets
-        - each pet in pets
-          li= pet
+```jade
+mixin pets(pets)
+  ul.pets
+    - each pet in pets
+      li= pet
 
-    mixin profile(user)
-      .user
-        h2= user.name
-        mixin pets(user.pets)
+mixin profile(user)
+  .user
+    h2= user.name
+    mixin pets(user.pets)
+```
 
    Would yield something similar to the following html:
 
@@ -968,9 +1134,11 @@ If we wanted to expose a different variable name as `user` since `user.jade` ref
 
  Suppose we have the following Jade:
 
-    - var title = 'yay'
-    h1.title #{title}
-    p Just an example
+```jade
+- var title = 'yay'
+h1.title #{title}
+p Just an example
+```
 
  When the `compileDebug` option is not explicitly `false`, Jade
  will compile the function instrumented with `__.lineno = n;`, which
@@ -1056,7 +1224,9 @@ clean:
 this can be combined with the `watch(1)` command to produce
 a watcher-like behaviour:
 
-    $ watch make
+```bash
+$ watch make
+```
 
 <a name="a17"/>
 ## jade(1)


### PR DESCRIPTION
I saw [this comment](https://github.com/visionmedia/jade/issues/558#issuecomment-4767983) and thought that it's cool that github can somewhat highlight Jade, so I added this highlighting to readme. While it's not perfect (there are some strange highlighting errors), I think it's still better than plain black text.

Also, added highlighting to bash strings.
