### PR TITLE
Pretty mixins

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -53,7 +53,6 @@ var Compiler = module.exports = function Compiler(node, options) {
   this.hasCompiledDoctype = false;
   this.hasCompiledTag = false;
   this.pp = options.pretty || false;
-  this.ppp = options.prettypretty || false;
   this.debug = false !== options.compileDebug;
   this.indents = 0;
   if (options.doctype) this.setDoctype(options.doctype);
@@ -73,7 +72,7 @@ Compiler.prototype = {
 
   compile: function(){
     this.buf = ['var interp;'];
-    if (this.ppp) this.buf.push("var __indent = ['\\n'];");
+    if (this.pp) this.buf.push("var __indent = ['\\n'];");
     this.lastBufferedIdx = -1;
     this.visit(this.node);
     return this.buf.join('\n');
@@ -251,9 +250,9 @@ Compiler.prototype = {
 
     if (mixin.block) {
       this.buf.push('var ' + name + ' = function(' + args + '){');
-      if (this.ppp) this.buf.push("__indent.push('  ');")
+      if (this.pp) this.buf.push("__indent.push('  ');")
       this.visit(mixin.block);
-      if (this.ppp) this.buf.push("__indent.pop();")
+      if (this.pp) this.buf.push("__indent.pop();")
       this.buf.push('}');
     } else {
       this.buf.push(name + '(' + args + ');');
@@ -271,7 +270,7 @@ Compiler.prototype = {
   visitTag: function(tag){
     this.indents++;
     var name = tag.name;
-    if (this.ppp && this.indents > 1) this.buf.push("__indent.push('  ');");
+    if (this.pp && this.indents > 1) this.buf.push("__indent.push('  ');");
 
     if (!this.hasCompiledTag) {
       if (!this.hasCompiledDoctype && 'html' == name) {
@@ -282,9 +281,6 @@ Compiler.prototype = {
 
     // pretty print
     if (this.pp && inlineTags.indexOf(name) == -1) {
-      this.buffer('\\n' + Array(this.indents).join('  '));
-    }
-    if (this.ppp && inlineTags.indexOf(name) == -1) {
       this.buf.push("buf.push.apply(buf, __indent);");
     }
 
@@ -310,15 +306,12 @@ Compiler.prototype = {
 
       // pretty print
       if (this.pp && !~inlineTags.indexOf(name) && !tag.textOnly && !tag.isText()) {
-        this.buffer('\\n' + Array(this.indents).join('  '));
-      }
-      if (this.ppp && !~inlineTags.indexOf(name) && !tag.textOnly && !tag.isText()) {
         this.buf.push("buf.push.apply(buf, __indent);");
       }
 
       this.buffer('</' + name + '>');
     }
-    if (this.ppp && this.indents > 1) this.buf.push('__indent.pop();');
+    if (this.pp && this.indents > 1) this.buf.push('__indent.pop();');
     this.indents--;
   },
 
@@ -373,10 +366,9 @@ Compiler.prototype = {
 
   visitComment: function(comment){
     if (!comment.buffer) return;
-    if (this.pp) this.buffer('\\n' + Array(this.indents + 1).join('  '));
-    if (this.ppp) {
+    if (this.pp) {
       this.buf.push("buf.push.apply(buf, __indent);");
-      this.buffer('  ');
+      if (this.indents > 0) this.buffer('  ');
     }
     this.buffer('<!--' + utils.escape(comment.val) + '-->');
   },

--- a/test/cases/filters.coffeescript.html
+++ b/test/cases/filters.coffeescript.html
@@ -4,8 +4,10 @@
 
   if (some && coffee) {
     script;
+
   } else {
     whoop;
+
   }
 
   foo('bar \'baz\' foobar');

--- a/test/cases/mixin-hoist.html
+++ b/test/cases/mixin-hoist.html
@@ -1,5 +1,5 @@
 <html>
   <body>
-<h1>Jade</h1>
+    <h1>Jade</h1>
   </body>
 </html>

--- a/test/cases/mixins.html
+++ b/test/cases/mixins.html
@@ -1,16 +1,16 @@
 <div id="user">
   <h1>Tobi</h1>
   <div class="comments">
-<div class="comment">
-  <h2>This</h2>
-  <p class="body">is regular, javascript</p>
-</div>
+    <div class="comment">
+      <h2>This</h2>
+      <p class="body">is regular, javascript</p>
+    </div>
   </div>
 </div>
 <body>
-<ul>
-  <li>foo</li>
-  <li>bar</li>
-  <li>baz</li>
-</ul>
+  <ul>
+    <li>foo</li>
+    <li>bar</li>
+    <li>baz</li>
+  </ul>
 </body>


### PR DESCRIPTION
Currently mixins have ugly whitespace.  This is because whitespace is hard-coded into the compiled jade.

This patch makes indentation dynamic.  Attention was given to use a performant approach.
