### PR TITLE
Improve performance of pretty mixins

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -55,6 +55,7 @@ var Compiler = module.exports = function Compiler(node, options) {
   this.pp = options.pretty || false;
   this.debug = false !== options.compileDebug;
   this.indents = 0;
+  this.parentIndents = 0;
   if (options.doctype) this.setDoctype(options.doctype);
 };
 
@@ -72,7 +73,7 @@ Compiler.prototype = {
 
   compile: function(){
     this.buf = ['var interp;'];
-    if (this.pp) this.buf.push("var __indent = ['\\n'];");
+    if (this.pp) this.buf.push("var __indent = [];");
     this.lastBufferedIdx = -1;
     this.visit(this.node);
     return this.buf.join('\n');
@@ -250,12 +251,14 @@ Compiler.prototype = {
 
     if (mixin.block) {
       this.buf.push('var ' + name + ' = function(' + args + '){');
-      if (this.pp) this.buf.push("__indent.push('  ');")
+      if (this.pp) this.parentIndents++;
       this.visit(mixin.block);
-      if (this.pp) this.buf.push("__indent.pop();")
+      if (this.pp) this.parentIndents--;
       this.buf.push('}');
     } else {
+      if (this.pp) this.buf.push("__indent.push('" + Array(this.indents + 1).join('  ') + "');")
       this.buf.push(name + '(' + args + ');');
+      if (this.pp) this.buf.push("__indent.pop();")
     }
   },
 
@@ -270,7 +273,6 @@ Compiler.prototype = {
   visitTag: function(tag){
     this.indents++;
     var name = tag.name;
-    if (this.pp && this.indents > 1) this.buf.push("__indent.push('  ');");
 
     if (!this.hasCompiledTag) {
       if (!this.hasCompiledDoctype && 'html' == name) {
@@ -281,7 +283,9 @@ Compiler.prototype = {
 
     // pretty print
     if (this.pp && inlineTags.indexOf(name) == -1) {
-      this.buf.push("buf.push.apply(buf, __indent);");
+      this.buffer('\\n' + Array(this.indents).join('  '));
+      if (this.parentIndents)
+        this.buf.push("buf.push.apply(buf, __indent);");
     }
 
     if (~selfClosing.indexOf(name) && !this.xml) {
@@ -306,12 +310,13 @@ Compiler.prototype = {
 
       // pretty print
       if (this.pp && !~inlineTags.indexOf(name) && !tag.textOnly && !tag.isText()) {
-        this.buf.push("buf.push.apply(buf, __indent);");
+        this.buffer('\\n' + Array(this.indents).join('  '));
+        if (this.parentIndents)
+          this.buf.push("buf.push.apply(buf, __indent);");
       }
 
       this.buffer('</' + name + '>');
     }
-    if (this.pp && this.indents > 1) this.buf.push('__indent.pop();');
     this.indents--;
   },
 
@@ -367,8 +372,9 @@ Compiler.prototype = {
   visitComment: function(comment){
     if (!comment.buffer) return;
     if (this.pp) {
-      this.buf.push("buf.push.apply(buf, __indent);");
-      if (this.indents > 0) this.buffer('  ');
+      this.buffer('\\n' + Array(this.indents + 1).join('  '));
+      if (this.parentIndents)
+          this.buf.push("buf.push.apply(buf, __indent);");
     }
     this.buffer('<!--' + utils.escape(comment.val) + '-->');
   },


### PR DESCRIPTION
The recent addition of pretty mixins degraded performance noticably for options like "compileDebug: false" or "self: true".

Now we only adjust the compiled jade where mixins are actually being called.

The performance when no mixins are present is now comparable to before.  The performance has also improved when mixins are being called.  This also works for pretty nested mixins.
