### PR TITLE
Issue #473 Multiline mixin arguments

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -369,7 +369,7 @@ Lexer.prototype = {
 
   mixin: function(){
     var captures;
-    if (captures = /^mixin +([-\w]+)(?: *\((.*)\))?/.exec(this.input)) {
+    if (captures = /^mixin +([-\w]+)(?: *\(((?:(\(.*?\))|(?:"[\s\S]*?")|(?:'[\s\S]*?')|(?:[\s\S])*?)*?)\))/.exec(this.input)) {
       this.consume(captures[0].length);
       var tok = this.tok('mixin', captures[1]);
       tok.args = captures[2];


### PR DESCRIPTION
Change the mixin regex to match mixin references whose arguments span multiple lines.

Regex includes support for quoted right parens and function references. eg:

mixin myAlreadyDefinedMixin('someValue', '$("#someID").addClass("someClass")', {someObject:
  {subparm1: "val1"},
  {subparm2: "val2"}},
  function() {
    i = 0;
  }
)
