### PR TITLE
Make block mixins work like blocks

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -55,6 +55,7 @@ var Compiler = module.exports = function Compiler(node, options) {
   this.debug = false !== options.compileDebug;
   this.indents = 0;
   this.parentIndents = 0;
+  this.mixing = 0;
   if (options.doctype) this.setDoctype(options.doctype);
 };
 
@@ -229,6 +230,11 @@ Compiler.prototype = {
    */
 
   visitBlock: function(block){
+    if (this.mixing && block.mode) {
+      this.buf.push('block && buf.push.apply(buf, block());');
+      return;
+    }
+    
     var len = block.nodes.length
       , escape = this.escape
       , pp = this.pp
@@ -288,23 +294,26 @@ Compiler.prototype = {
           this.buf.push(name + '(function(){');
         }
         this.buf.push('var buf = [];');
-        this.indents++;
+        this.parentIndents++, this.indents++;
+        var _indents = this.indents;
+        this.indents = 1;
         this.visit(mixin.block);
-        this.indents--;
-        this.buf.push('return buf.join("");');
-        this.buf.push('}());\n');
+        this.indents = _indents - this.indents;
+        this.parentIndents--;
+        this.buf.push('return buf;');
+        this.buf.push('});\n');
       } else {
         this.buf.push(name + '(' + args + ');');
       }
       if (this.pp) this.buf.push("__indent.pop();")
     } else {
       args = args
-        ? args.split(/ *, */).concat('content').join(', ')
-        : 'content';
+        ? args.split(/ *, */).concat('block').join(', ')
+        : 'block';
       this.buf.push('var ' + name + ' = function(' + args + '){');
-      if (this.pp) this.parentIndents++;
+      this.parentIndents++, this.mixing++;
       this.visit(mixin.block);
-      if (this.pp) this.parentIndents--;
+      this.parentIndents--, this.mixing--;
       this.buf.push('}');
     }
   },

--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -299,7 +299,7 @@ Lexer.prototype = {
   
   block: function() {
     var captures;
-    if (captures = /^block +(?:(prepend|append) +)?([^\n]+)/.exec(this.input)) {
+    if (captures = /^block *(?:(prepend|append) +)?([^\n]*)/.exec(this.input)) {
       this.consume(captures[0].length);
       var mode = captures[1] || 'replace'
         , name = captures[2]

--- a/test/cases/mixin.blocks.html
+++ b/test/cases/mixin.blocks.html
@@ -2,8 +2,8 @@
   <body>
     <form method="GET" action="/search">
       <input type="hidden" name="_csrf" value="hey"/>
-    <input type="text" name="query" placeholder="Search"/>
-    <input type="submit" value="Search"/>
+      <input type="text" name="query" placeholder="Search"/>
+      <input type="submit" value="Search"/>
     </form>
   </body>
 </html>
@@ -11,8 +11,8 @@
   <body>
     <form method="POST" action="/search">
       <input type="hidden" name="_csrf" value="hey"/>
-    <input type="text" name="query" placeholder="Search"/>
-    <input type="submit" value="Search"/>
+      <input type="text" name="query" placeholder="Search"/>
+      <input type="submit" value="Search"/>
     </form>
   </body>
 </html>
@@ -25,7 +25,8 @@
 </html>
 <div id="foo">
   <div id="bar">
-<p>one</p>
-<p>two</p>
-<p>three</p></div>
+    <p>one</p>
+    <p>two</p>
+    <p>three</p>
+  </div>
 </div>

--- a/test/cases/mixin.blocks.jade
+++ b/test/cases/mixin.blocks.jade
@@ -4,7 +4,7 @@ mixin form(method, action)
   form(method=method, action=action)
     csrf_token_from_somewhere = 'hey'
     input(type='hidden', name='_csrf', value=csrf_token_from_somewhere)
-    != content
+    block
 
 html
   body
@@ -22,12 +22,13 @@ html
   body
     +form('POST', '/search')
 
-mixin bar(html)
-  #bar!= html
+mixin bar()
+  #bar
+    block
 
 mixin foo()
   #foo
-    +bar(content)
+    +bar(block)
 
 +foo
   p one


### PR DESCRIPTION
I removed the `contents`-style block keyword and used `block` instead.

Now you just put `block` in the mixin where you want the block to appear.

Everything indents nicely too.
