### PR TITLE
Use explicit `block` notation

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -236,7 +236,7 @@ Compiler.prototype = {
     // Block keyword has a special meaning in mixins
     if (this.parentIndents && block.mode) {
       if (pp) this.buf.push("__indent.push('" + Array(this.indents + 1).join('  ') + "');")
-      this.buf.push('block && this.block();');
+      this.buf.push('block && block();');
       if (pp) this.buf.push("__indent.pop();")
       return;
     }
@@ -307,16 +307,12 @@ Compiler.prototype = {
           this.buf.push('}});');
         }
       } else {
-        if (args) {
-          this.buf.push(name + '.call(this, ' + args + ');');
-        } else {
-          this.buf.push(name + '.call(this);');
-        }
+        this.buf.push(name + '(' + args + ');');
       }
       if (pp) this.buf.push("__indent.pop();")
     } else {
       this.buf.push('var ' + name + ' = function(' + args + '){');
-      this.buf.push('var block = !!this.block;');
+      this.buf.push('var block = this.block;');
       this.parentIndents++;
       this.visit(mixin.block);
       this.parentIndents--;

--- a/test/cases/mixin.blocks.jade
+++ b/test/cases/mixin.blocks.jade
@@ -29,6 +29,7 @@ mixin bar()
 mixin foo()
   #foo
     +bar
+      block
 
 +foo
   p one


### PR DESCRIPTION
Blocks should not be passed along to junior mixins automatically.  They should work just like normal in a mixin call's block:

```
mixin bar
  block

mixin foo
  +bar
    block

+foo
  p Hello world!
```

Also allows for things which are useful, like this:

```
mixin foo(title)
  +bar
    h1= title
    block
```
