### PR TITLE
Parse mixin call like a tag

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -496,13 +496,12 @@ Parser.prototype = {
     var tok = this.expect('call')
       , name = tok.val
       , args = tok.args
-      , mixin = this.mixins[name];
+      , mixin = new nodes.Mixin(name, args, new nodes.Block, true);
 
-    var block = 'indent' == this.peek().type
-      ? this.block()
-      : null;
-
-    return new nodes.Mixin(name, args, block, true);
+    this.tag(mixin);
+    if (!mixin.block.nodes.length)
+      mixin.block = null;
+    return mixin;
   },
 
   /**
@@ -592,11 +591,8 @@ Parser.prototype = {
     }
 
     var name = this.advance().val
-      , tag = new nodes.Tag(name)
-      , dot;
-
-    tag.line = this.line();
-
+      , tag = new nodes.Tag(name);
+    
     // (attrs | class | id)*
     out:
       while (true) {
@@ -622,6 +618,14 @@ Parser.prototype = {
             break out;
         }
       }
+    
+    return this.tag(tag);
+  },
+  
+  tag: function(tag){
+    var dot;
+
+    tag.line = this.line();
 
     // check immediate '.'
     if ('.' == this.peek().val) {
@@ -650,7 +654,7 @@ Parser.prototype = {
     tag.textOnly = tag.textOnly || ~textOnly.indexOf(tag.name);
 
     // script special-case
-    if ('script' == tag.name) {
+    if ('script' == tag.name && tag.getAttribute) {
       var type = tag.getAttribute('type');
       if (!dot && type && 'text/javascript' != type.replace(/^['"]|['"]$/g, '')) {
         tag.textOnly = false;


### PR DESCRIPTION
By extracting the tag-parser, we can apply it to mixins.  This makes mixin `block`s more robust and consistent with how tags work:

The following both work now:

```
+foo: p Hi!
+foo.
  Hello
  World!
```
