### PR TITLE
Make mixins available if defined in the same file as `extends`

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -136,11 +136,15 @@ Parser.prototype = {
       var ast = parser.parse();
       this.context();
       // hoist mixins
-      for (var name in this.mixins)
+      ast.mixins = this.mixins;
+      for (var name in this.mixins) {
         ast.unshift(this.mixins[name]);
+        ast.mixins[name] = this.mixins[name];
+      }
       return ast;
     }
 
+    block.mixins = this.mixins;
     return block;
   },
   
@@ -487,6 +491,9 @@ Parser.prototype = {
     if ('indent' == this.peek().type) {
       ast.includeBlock().push(this.block());
     }
+
+    for (var name in ast.mixins)
+      this.mixins[name] = ast.mixins[name];
 
     return ast;
   },


### PR DESCRIPTION
Addresses issue #582.

(May as well use `this.mixins` 'cause it ain't used anywhere else.)
