### PR TITLE
Update docs for default doctype (now HTML5)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -50,7 +50,7 @@
   - code is escaped by default for security
   - contextual error reporting at compile &amp; run time
   - executable for compiling jade templates via the command line
-  - html 5 mode (using the _!!! 5_ doctype)
+  - html 5 mode (the default doctype)
   - optional memory caching
   - combine dynamic and static tag classes
   - parse tree manipulation via _filters_
@@ -608,25 +608,19 @@ To add a doctype simply use `!!!`, or `doctype` followed by an optional value:
 !!!
 ```
 
-Will output the _transitional_ doctype, however:
-
-```jade
-!!! 5
-```
-
 or
 
 ```jade
-!!! html
+doctype
 ```
 
-or
+Will output the _html 5_  doctype, however:
 
 ```jade
-doctype html
+!!! transitional
 ```
 
-Will output the _html 5_ doctype.
+Will output the _transitional_ doctype.
 
 Doctypes are case-insensitive, so the following are equivalent:
 
@@ -652,8 +646,8 @@ Below are the doctypes defined by default, which can easily be extended:
 ```js
 var doctypes = exports.doctypes = {
   '5': '<!DOCTYPE html>',
+  'default': '<!DOCTYPE html>',
   'xml': '<?xml version="1.0" encoding="utf-8" ?>',
-  'default': '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">',
   'transitional': '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">',
   'strict': '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">',
   'frameset': '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Frameset//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd">',


### PR DESCRIPTION
The documentation for the default doctype has been out of date since 1e7bcbd7. This patch updates them, fixing issue #701.
