### PR TITLE
Excluding certain files from compilation

### DIFF
--- a/bin/jade
+++ b/bin/jade
@@ -135,7 +135,7 @@ function stdin() {
  */
 
 function renderFile(path) {
-  re = /\.jade$/
+  re = /\.jade$/;
   if (options.exclude.test(basename(path)))
     return;
   fs.lstat(path, function(err, stat) {


### PR DESCRIPTION
When compiling directories with jade (e.g. jade -P src/jade -O web) you don't want files that have already been included to be compiled and copied to the output directory. For example if I have index.jade which include header.jade, I don't want header.html to appear.

I added an option to jade compiler for excluding files. You use it like:
  jade -e '^_.*' -P src/jade -O web
This causes that compilation doesn't process files starting with underscore. Now you can include _header.jade from the index.jade and the _header.jade isn't compiled to target directory.
