### PR TITLE
Fixes default (now HTML 5) terse boolean.

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -90,8 +90,7 @@ Compiler.prototype = {
 
   setDoctype: function(name){
     name = (name && name.toLowerCase()) || 'default';
-    var doctype = doctypes[name] || '<!DOCTYPE ' + name + '>';
-    this.doctype = doctype;
+    this.doctype = doctypes[name] || '<!DOCTYPE ' + name + '>';
     this.terse = 'default' == name || '5' == name || 'html' == name;
     this.xml = 0 == this.doctype.indexOf('<?xml');
   },


### PR DESCRIPTION
This keeps the tags consistent when using `!!!` or `!!! 5` or `!!! html`. The current code will give `/>` endings for the default doctype.
