### PR TITLE
Fixes doctype bug overlooked in #712

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -91,7 +91,7 @@ Compiler.prototype = {
   setDoctype: function(name){
     name = (name && name.toLowerCase()) || 'default';
     this.doctype = doctypes[name] || '<!DOCTYPE ' + name + '>';
-    this.terse = 'default' == name || '5' == name || 'html' == name;
+    this.terse = this.doctype.toLowerCase() == '<!doctype html>';
     this.xml = 0 == this.doctype.indexOf('<?xml');
   },
 


### PR DESCRIPTION
I forgot to consider someone changing the default with `jade.doctypes.default = 'foo'`. The previous PR didn't account for this and assumed terse for any default. This commit corrects that.
