### PR TITLE
fix --watch

### DIFF
--- a/bin/jade
+++ b/bin/jade
@@ -95,10 +95,8 @@ if (files.length) {
   files.forEach(renderFile);
   if (options.watch) {
     files.forEach(function (file) {
-      fs.watchFile(file, {persistent: true, interval: 500}, function (prev, curr) {
-        if (prev.size !== curr.size && prev.mtime.getTime() !== curr.mtime.getTime()) {
-          renderFile(file);
-        }
+      fs.watchFile(file, {interval: 100}, function (curr, prev) {
+        if (curr.mtime > prev.mtime) renderFile(file);
       });
     });
   }


### PR DESCRIPTION
`-w` behaves strangely on my Ubuntu 12.04 ,
`curr` and `prev` parameters was placed at wrong positions according to API docs:
http://nodejs.org/api/fs.html#fs_fs_watchfile_filename_options_listener
and use the code of Stylus to rewrite `--watch`:
https://github.com/LearnBoost/stylus/blob/master/bin/stylus#L575
