### PR TITLE
Include Readme.md in package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,7 +7,6 @@ coverage.html
 .gitmodules
 .travis.yml
 History.md
-Readme.md
 Makefile
 test/
 support/


### PR DESCRIPTION
npm now expects a readme and if it doesn't see one, it gives a warning.
