### PR TITLE
Change code flags string access to chartAt for IE7

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -1,4 +1,3 @@
-
 /*!
  * Jade - Lexer
  * Copyright(c) 2010 TJ Holowaychuk <tj@vision-media.ca>
@@ -475,8 +474,8 @@ Lexer.prototype = {
       var flags = captures[1];
       captures[1] = captures[2];
       var tok = this.tok('code', captures[1]);
-      tok.escape = flags[0] === '=';
-      tok.buffer = flags[0] === '=' || flags[1] === '=';
+      tok.escape = flags.charAt(0) === '=';
+      tok.buffer = flags.charAt(0) === '=' || flags.charAt(1) === '=';
       return tok;
     }
   },


### PR DESCRIPTION
Change code flags string access to chartAt instead of [x] for IE7 compatibility. (extends on #512)
