### PR TITLE
Improve report of disk-usage on minified versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,16 +24,14 @@ jade.js: $(SRC)
 
 jade.min.js: jade.js
 	@$(UGLIFY) $(UGLIFY_FLAGS) $< > $@ \
-		&& du jade.min.js \
-		&& du jade.js
+		&& du -bh jade.js jade.min.js
 
 runtime.js: lib/runtime.js
 	@cat support/head.js $< support/foot.js > $@
 
 runtime.min.js: runtime.js
 	@$(UGLIFY) $(UGLIFY_FLAGS) $< > $@ \
-	  && du runtime.min.js \
-	  && du runtime.js
+	  && du -bh runtime.js runtime.min.js
 
 clean:
 	rm -f jade.js


### PR DESCRIPTION
This patch makes disk-usage report little bit more useful.
Here's visual example of `du` vs ``du -bh`:

```
% du jade.js jade.min.js runtime.js runtime.min.js
76      jade.js
40      jade.min.js
4       runtime.js
4       runtimeruntime.min.js

% du -bh jade.js jade.min.js runtime.js runtime.min.js
74K     jade.js
40K     jadejade.min.js
3.6K    runtime.js
1.8K    runtime.min.js
```
