### PR TITLE
added option to inline images (base64) with stylus

### DIFF
--- a/lib/filters.js
+++ b/lib/filters.js
@@ -33,7 +33,7 @@ module.exports = {
     str = str.replace(/\\n/g, '\n');
     var stylus = require('stylus');
 
-    style = stylus(str, options);
+    var style = stylus(str, options);
 
     if(options.inline == "true"){
       style.define('url', stylus.url({}));


### PR DESCRIPTION
simple example of the syntax for telling stylus to inline images

```
:stylus(inline=true)
    @import 'stylus/main'
```

this function is explained in more detail in the stylus docs: http://learnboost.github.com/stylus/docs/functions.url.html
