### PR TITLE
package: loosen "mkdirp" version restriction

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "man": "./jade.1",
   "dependencies": {
     "commander": "0.6.1",
-    "mkdirp": "0.3.0"
+    "mkdirp": "0.3.x"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
Otherwise installing "mocha" ends up with 2 versions of mkdirp!
