### PR TITLE
Prevent runtime.js failure on IE8

### DIFF
--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -23,7 +23,7 @@ if (!Object.keys) {
   Object.keys = function(obj){
     var arr = [];
     for (var key in obj) {
-      if (obj.hasOwnProperty(key)) {
+      if (obj.hasOwnProperty && obj.hasOwnProperty(key)) {
         arr.push(key);
       }
     }


### PR DESCRIPTION
An issue with hasOwnProperty occurs in IE8. The DispHTMLWindow2 object does not have the hasOwnProperty method, which causes jade/runtime.js to fail. Fixed by checking for existence of method before calling...
