### PR TITLE
Fix each/else with leading `- `

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -471,7 +471,7 @@ Lexer.prototype = {
   
   code: function() {
     var captures;
-    if (captures = /^(!?=|-)([^\n]+)/.exec(this.input)) {
+    if (captures = /^(!?=|-\s*)([^\n]+)/.exec(this.input)) {
       this.consume(captures[0].length);
       var flags = captures[1];
       captures[1] = captures[2];

--- a/test/cases/each.else.html
+++ b/test/cases/each.else.html
@@ -12,3 +12,6 @@
 <ul>
   <li>user has no details!</li>
 </ul>
+<ul>
+  <li>user has no details!</li>
+</ul>

--- a/test/cases/each.else.jade
+++ b/test/cases/each.else.jade
@@ -32,3 +32,11 @@ ul
     li #{key}: #{val}
   else
     li user has no details!
+
+user = {}
+
+ul
+  - each prop, key in user
+    li #{key}: #{val}
+  - else
+    li user has no details!


### PR DESCRIPTION
It looks like you're moving away from `-` prefixed Jade-level control structures (is that right?). However, while the following is still supported:

``` jade
- each item in items
  p= item
```

…it makes sense that this is too:

``` jade
- each item in items
  p= item
- else
  p no items
```

Currently this results in an 'unexpected else' error. I have updated the test to reflect this use case.

The fix involves stripping leading whitespace from the code block in the lexer, revealing that the following was already valid:

``` jade
-each item in items
  p= item
-else
  p no items
```

So the thing that was unexpected was that the token's value being `else` instead of `else`.

Hope this is alright.
