### PR TITLE
&-sequences processing in escape() from /lib/runtime.js fix

### DIFF
--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -132,7 +132,7 @@ exports.attrs = function attrs(obj, escaped){
 
 exports.escape = function escape(html){
   return String(html)
-    .replace(/&(\w+|\#\d+);/g, '&amp;$1;')
+    .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;');

--- a/test/cases/escape-test.html
+++ b/test/cases/escape-test.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>escape-test</title>
+  </head>
+  <body>
+    <textarea>&lt;param name=&quot;flashvars&quot; value=&quot;a=&amp;quot;value_a&amp;quot;&amp;b=&amp;quot;value_b&amp;quot;&amp;c=3&quot;/&gt;
+    </textarea>
+  </body>
+</html>

--- a/test/cases/escape-test.jade
+++ b/test/cases/escape-test.jade
@@ -1,0 +1,8 @@
+!!! 5
+html
+    head
+        title escape-test
+    body
+        textarea
+            - var txt = '<param name="flashvars" value="a=&quot;value_a&quot;&b=&quot;value_b&quot;&c=3"/>'
+            | #{txt}


### PR DESCRIPTION
I described problem in issue #810. This pull request can fix this bug so Jade can correctly escape &-sequences like `&quot;`.
