### PR TITLE
Allow multiline mixin arguments (rebase)

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -133,6 +133,59 @@ Lexer.prototype = {
     }
     return pos;
   },
+
+  /**
+   * Match everything in parentheses.
+   *
+   * We do not including matched parentheses () or parentheses contained in
+   * quotation marks "(".  We also ignore newlines.
+   *
+   * Otherwise, this is similar to doing /\((.*)\)/.exec()
+   *
+   * @param {String} input
+   * @return {Array}
+   * @api private
+   */
+
+  matchArgs: function(str){
+    var startpos = -1;
+    while (str[++startpos] === ' ') {}
+    if (str[startpos] !== '(') return null;
+    
+    var endpos = startpos
+      , ctr = 1
+      , chr = ''
+      , quot = ''
+      , len = str.length-1
+      , skip = false;
+    
+    while ((ctr > 0) && (endpos < len)) {
+      chr = str[++endpos];
+      if (skip) {
+        skip = false;
+        continue;
+      }
+      
+      switch (chr) {
+        case '\\':
+          skip = true;
+          break;
+        case "'":
+        case '"':
+          if (chr === quot) quot = '';
+          else if ('' === quot) quot = chr;
+          break;
+        case '(':
+          if (!quot) ++ctr;
+          break;
+        case ')':
+          if (!quot) --ctr;
+          break;
+      }
+    }
+    
+    return [str.substring(0, endpos+1), str.substring(startpos+1, endpos)];
+  },
   
   /**
    * Stashed token.
@@ -388,15 +441,12 @@ Lexer.prototype = {
     if (captures = /^\+([-\w]+)/.exec(this.input)) {
       this.consume(captures[0].length);
       var tok = this.tok('call', captures[1]);
-      
-      // Check for args (not attributes)
-      if (captures = /^ *\((.*?)\)/.exec(this.input)) {
-        if (!/^ *[-\w]+ *=/.test(captures[1])) {
+      if (captures = this.matchArgs(this.input)) {
+        if (!/^ *[-\w]+ *=|^ *attributes *(?:,|$)/.test(captures[1])) {
           this.consume(captures[0].length);
           tok.args = captures[1];
         }
       }
-      
       return tok;
     }
   },
@@ -407,10 +457,13 @@ Lexer.prototype = {
 
   mixin: function(){
     var captures;
-    if (captures = /^mixin +([-\w]+)(?: *\((.*)\))?/.exec(this.input)) {
+    if (captures = /^mixin +([-\w]+)/.exec(this.input)) {
       this.consume(captures[0].length);
       var tok = this.tok('mixin', captures[1]);
-      tok.args = captures[2];
+      if (captures = this.matchArgs(this.input)) {
+        this.consume(captures[0].length);
+        tok.args = captures[1];
+      }
       return tok;
     }
   },

--- a/test/cases/mixin.multiline.args.html
+++ b/test/cases/mixin.multiline.args.html
@@ -1,0 +1,11 @@
+
+<ul>
+  <li>Hello: world</li>
+</ul>
+<ul>
+  <li>first: line</li>
+  <li>second: line</li>
+</ul>
+<ul>
+  <li>world: Hello</li>
+</ul>

--- a/test/cases/mixin.multiline.args.jade
+++ b/test/cases/mixin.multiline.args.jade
@@ -1,0 +1,18 @@
+mixin test(obj)
+  ul
+    each val, key in obj
+      li #{key}: #{val}
+
++test({"Hello": "world"})
++test({
+  "first": "line",
+  "second": "line"
+})
++test(function(obj){
+  /* Swap the key/value pairs */
+  var nobj = {}
+  for (var key in obj) {
+    nobj[obj[key]] = key;
+  }
+  return nobj;
+}({"Hello": "world"}))


### PR DESCRIPTION
rebased version of #629 ... 78/78 (all) tests pass

Closes #473, addresses it in a more thorough way.
