### PR TITLE
changing how class escaping works

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -601,11 +601,11 @@ Compiler.prototype = {
 
     if (classes.length) {
       classes = classes.join(" + ' ' + ");
-      buf.push("class: " + classes);
+      buf.push('"class": ' + classes);
     }
 
     return {
-      buf: buf.join(', ').replace('class:', '"class":'),
+      buf: buf.join(', '),
       escaped: JSON.stringify(escaped),
       inherits: inherits,
       constant: constant

--- a/test/cases/attrs.html
+++ b/test/cases/attrs.html
@@ -2,4 +2,4 @@
 <select>
   <option value="foo" selected="selected">Foo</option>
   <option selected="selected" value="bar">Bar</option>
-</select>
+</select><a foo="class:"></a>

--- a/test/cases/attrs.jade
+++ b/test/cases/attrs.jade
@@ -6,3 +6,4 @@ a(foo='((foo))', bar= (1) ? 1 : 0 )
 select
   option(value='foo', selected) Foo
   option(selected, value='bar') Bar
+a(foo="class:")


### PR DESCRIPTION
Aiming to fix #548.  I'm not sure if there's some other case where we need `s/class:/"class:"`, so possibly I'm missing something. The tests do pass, though.
