### PR TITLE
Support for treating the Jade repo as the jade-js-source ruby gem

### DIFF
--- a/jade.gemspec
+++ b/jade.gemspec
@@ -1,0 +1,17 @@
+require "json"
+package_info = JSON.load open(File.expand_path("../package.json", __FILE__)).read
+
+RUBY_LIB_PATH = File.join("support", "ruby")
+
+Gem::Specification.new do |gem|
+  gem.name     = "jade-js-source"
+  gem.summary  = package_info["description"]
+  gem.authors  = [package_info["author"]]
+  gem.homepage = "http://jade-lang.com/"
+
+  gem.version  = package_info["version"]
+  gem.platform = Gem::Platform::RUBY
+
+  gem.files         = ["jade.js", "runtime.js", File.join(RUBY_LIB_PATH, "jade_js", "source.rb")]
+  gem.require_paths = [RUBY_LIB_PATH]
+end

--- a/support/ruby/jade_js/source.rb
+++ b/support/ruby/jade_js/source.rb
@@ -1,0 +1,13 @@
+module JadeJs
+  module Source
+
+    def self.bundled_path
+      File.expand_path("../../../../jade.js", __FILE__)
+    end
+
+    def self.bundled_runtime_path
+      File.expand_path("../../../../runtime.js", __FILE__)
+    end
+
+  end
+end


### PR DESCRIPTION
Makes things a little nicer for those of us stuck in the old world, especially when forking/testing new changes to Jade proper.

I wouldn't be surprised if you reject this; but here's to hoping :P
