### PR TITLE
move filters to an external library

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -406,17 +406,12 @@ Compiler.prototype = {
    */
 
   visitFilter: function(filter){
-    var fn = filters[filter.name];
-
-    // unknown filter
-    if (!fn) throw new Error('unknown filter ":' + filter.name + '"');
-
     var text = filter.block.nodes.map(
       function(node){ return node.val; }
     ).join('\n');
     filter.attrs = filter.attrs || {};
     filter.attrs.filename = this.options.filename;
-    this.buffer(utils.text(fn(text, filter.attrs)));
+    this.buffer(utils.text(filters(filter.name, text, filter.attrs).replace(/\\/g, '\\\\')));
   },
 
   /**

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -1,105 +1,29 @@
-
 /*!
  * Jade - filters
  * Copyright(c) 2010 TJ Holowaychuk <tj@vision-media.ca>
  * MIT Licensed
  */
 
-/**
- * Wrap text with CDATA block.
- */
+var transformers = require('transformers');
 
-exports.cdata = function(str){
-  return '<![CDATA[\\n' + str + '\\n]]>';
-};
-
-/**
- * Wrap text in script tags.
- */
-
-exports.js = function(str){
-  return '<script>' + str + '</script>';
-};
-
-/**
- * Wrap text in style tags.
- */
-
-exports.css = function(str){
-  return '<style>' + str + '</style>';
-};
-
-/**
- * Transform stylus to css, wrapped in style tags.
- */
-
-exports.stylus = function(str, options){
-  var ret;
-  str = str.replace(/\\n/g, '\n');
-  var stylus = require('stylus');
-  stylus(str, options).render(function(err, css){
-    if (err) throw err;
-    ret = css;
-  });
-  return '<style type="text/css">' + ret + '</style>';
-};
-
-/**
- * Transform less to css, wrapped in style tags.
- */
-
-exports.less = function(str){
-  var ret;
-  str = str.replace(/\\n/g, '\n');
-  require('less').render(str, function(err, css){
-    if (err) throw err;
-    ret = '<style type="text/css">' + css + '</style>';
-  });
-  return ret;
-};
-
-/**
- * Transform markdown to html.
- */
-
-exports.markdown = function(str){
-  var md;
-
-  // support markdown / discount
-  try {
-    md = require('markdown');
-  } catch (err){
-    try {
-      md = require('discount');
-    } catch (err) {
-      try {
-        md = require('markdown-js');
-      } catch (err) {
-        try {
-          md = require('marked');
-        } catch (err) {
-          throw new
-            Error('Cannot find markdown library, install markdown, discount, or marked.');
-        }
-      }
+module.exports = filter;
+function filter(name, str, options) {
+  if (typeof filter[name] === 'function') {
+    var res = filter[name](str, options);
+  } else if (transformers[name]) {
+    var res = transformers[name].renderSync(str, options);
+    if (transformers[name].outputFormat === 'js') {
+      res = '<script type="text/javascript">\n' + res + '</script>';
+    } else if (transformers[name].outputFormat === 'css') {
+      res = '<style type="text/css">' + res + '</style>';
+    } else if (transformers[name].outputFormat === 'xml') {
+      res = res.replace(/'/g, '&#39;');
     }
+  } else {
+    throw new Error('unknown filter ":' + name + '"');
   }
-
-  str = str.replace(/\\n/g, '\n');
-  return md.parse(str).replace(/'/g,'&#39;');
+  return res;
+}
+filter.exists = function (name, str, options) {
+  return typeof filter[name] === 'function' || transformers[name];
 };
-
-/**
- * Transform coffeescript to javascript.
- */
-
-exports.coffeescript = function(str){
-  var js = require('coffee-script').compile(str).replace(/\\/g, '\\\\').replace(/\n/g, '\\n');
-  return '<script type="text/javascript">\\n' + js + '</script>';
-};
-
-// aliases
-
-exports.md = exports.markdown;
-exports.styl = exports.stylus;
-exports.coffee = exports.coffeescript;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -466,9 +466,7 @@ Parser.prototype = {
       var path = join(dir, path);
       var str = fs.readFileSync(path, 'utf8').replace(/\r/g, '');
       var ext = extname(path).slice(1);
-      var filter = filters[ext];
-      if (filter) str = filter(str, { filename: path });
-
+      if (filters.exists(ext)) str = filters(ext, str, { filename: path });
       return new nodes.Literal(str);
     }
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "man": "./jade.1",
   "dependencies": {
     "commander": "0.6.1",
-    "mkdirp": "0.3.x"
+    "mkdirp": "0.3.x",
+    "transformers": "~1.8.0"
   },
   "devDependencies": {
     "coffee-script": "*",

--- a/test/cases/includes-with-ext-js.html
+++ b/test/cases/includes-with-ext-js.html
@@ -1,5 +1,6 @@
 <html>
-  <body><script>var x = "\n here is some \n new lined text";
+  <body><script type="text/javascript">
+var x = "\n here is some \n new lined text";
 </script>
   </body>
 </html>

--- a/test/jade.test.js
+++ b/test/jade.test.js
@@ -25,7 +25,7 @@ describe('jade', function(){
     it('should have exports', function(){
       assert.equal('object', typeof jade.selfClosing, 'exports.selfClosing missing');
       assert.equal('object', typeof jade.doctypes, 'exports.doctypes missing');
-      assert.equal('object', typeof jade.filters, 'exports.filters missing');
+      assert.equal('function', typeof jade.filters, 'exports.filters missing');
       assert.equal('object', typeof jade.utils, 'exports.utils missing');
       assert.equal('function', typeof jade.Compiler, 'exports.Compiler missing');
     });


### PR DESCRIPTION
Rebase of #857

This makes filters just use an external library. It uses transformers which supports all the same filters as jade so there's no loss of functionality. There are loads of additional filters that are then supported, which I think is really useful.

We could move `transformers` and `coffee-script` into `devDependencies` and let people install them only if needed?

P.S.`transformers` works like `consolidate.js` and does not install the dependencies itself, but lets you install the ones you need.
