### PR TITLE
Improve `find` call in Readme's example Makefile

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1208,7 +1208,7 @@ function anonymous(locals) {
 _Note:_ If you try to run this snippet and `make` throws a `missing separator` error, you should make sure all indented lines use a tab for indentation instead of spaces. (For whatever reason, GitHub renders this code snippet with 4-space indentation although the actual README file uses tabs in this snippet.)
 
 ```make
-JADE = $(shell find pages/*.jade)
+JADE = $(shell find -wholename './pages/*.jade')
 HTML = $(JADE:.jade=.html)
 
 all: $(HTML)


### PR DESCRIPTION
Now finds all `.jade` files in any subdirectory of `pages` too.
This is an improvement because template directories are often deep.
