### PR TITLE
more hygenic compiled functions

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -317,8 +317,8 @@ Compiler.prototype = {
         if (attrs.length) {
           var val = this.attrs(attrs);
           if (val.inherits) {
-            this.buf.push('attributes: merge({' + val.buf
-                + '}, attributes), escaped: merge(' + val.escaped + ', escaped, true)');
+            this.buf.push('attributes: $merge({' + val.buf
+                + '}, attributes), escaped: $merge(' + val.escaped + ', escaped, true)');
           } else {
             this.buf.push('attributes: {' + val.buf + '}, escaped: ' + val.escaped);
           }
@@ -485,7 +485,7 @@ Compiler.prototype = {
       var val = code.val.trimLeft();
       this.buf.push('var __val__ = ' + val);
       val = 'null == __val__ ? "" : __val__';
-      if (code.escape) val = 'escape(' + val + ')';
+      if (code.escape) val = '$escape(' + val + ')';
       this.buf.push("buf.push(" + val + ");");
     } else {
       this.buf.push(code.val);
@@ -565,13 +565,13 @@ Compiler.prototype = {
   visitAttributes: function(attrs){
     var val = this.attrs(attrs);
     if (val.inherits) {
-      this.buf.push("buf.push(attrs(merge({ " + val.buf +
-          " }, attributes), merge(" + val.escaped + ", escaped, true)));");
+      this.buf.push("buf.push($attrs($merge({ " + val.buf +
+          " }, attributes), $merge(" + val.escaped + ", escaped, true)));");
     } else if (val.constant) {
       eval('var buf={' + val.buf + '};');
       this.buffer(runtime.attrs(buf, JSON.parse(val.escaped)), true);
     } else {
-      this.buf.push("buf.push(attrs({ " + val.buf + " }, " + val.escaped + "));");
+      this.buf.push("buf.push($attrs({ " + val.buf + " }, " + val.escaped + "));");
     }
   },
 

--- a/lib/jade.js
+++ b/lib/jade.js
@@ -162,7 +162,7 @@ exports.compile = function(str, options){
       , 'try {'
       , parse(str, options)
       , '} catch (err) {'
-      , '  rethrow(err, __jade[0].filename, __jade[0].lineno);'
+      , '  $rethrow(err, __jade[0].filename, __jade[0].lineno);'
       , '}'
     ].join('\n');
   } else {
@@ -170,10 +170,10 @@ exports.compile = function(str, options){
   }
 
   if (client) {
-    fn = 'attrs = attrs || jade.attrs; escape = escape || jade.escape; rethrow = rethrow || jade.rethrow; merge = merge || jade.merge;\n' + fn;
+    fn = '$attrs = $attrs || jade.attrs; $escape = $escape || jade.escape; $rethrow = $rethrow || jade.rethrow; $merge = $merge || jade.merge;\n' + fn;
   }
 
-  fn = new Function('locals, attrs, escape, rethrow, merge', fn);
+  fn = new Function('locals, $attrs, $escape, $rethrow, $merge', fn);
 
   if (client) return fn;
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -22,7 +22,7 @@ var interpolate = exports.interpolate = function(str){
     return escape
       ? str.slice(7)
       : "' + "
-        + ('!' == flag ? '' : 'escape')
+        + ('!' == flag ? '' : '$escape')
         + "((interp = " + code
         + ") == null ? '' : interp) + '";
   });


### PR DESCRIPTION
if the `locals` object contained an `attrs` property it would end up overwritting the local utility function also called `attrs`. I have given all the utility function a "$" namespace to reduce the chance of conflicts. Hopefully I got all the places they are added to the buffer. The tests pass though.
