### PR TITLE
du has no -b option under MacOS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,14 +24,14 @@ jade.js: $(SRC)
 
 jade.min.js: jade.js
 	@$(UGLIFY) $(UGLIFY_FLAGS) $< > $@ \
-		&& du -bh jade.js jade.min.js
+		&& du -h jade.js jade.min.js
 
 runtime.js: lib/runtime.js
 	@cat support/head.js $< support/foot.js > $@
 
 runtime.min.js: runtime.js
 	@$(UGLIFY) $(UGLIFY_FLAGS) $< > $@ \
-	  && du -bh runtime.js runtime.min.js
+	  && du -h runtime.js runtime.min.js
 
 clean:
 	rm -f jade.js


### PR DESCRIPTION
Now make works ok under MacOS X without installing of coreutils.
