### PR TITLE
Minor optimization of Tag.canInline method.

### DIFF
--- a/lib/nodes/tag.js
+++ b/lib/nodes/tag.js
@@ -75,15 +75,16 @@ Tag.prototype.canInline = function(){
     return node.isText || (node.isInline && node.isInline());
   }
   
+  var len = nodes.length;
   // Empty tag
-  if (!nodes.length) return true;
+  if (!len) return true;
   
   // Text-only or inline-only tag
-  if (1 == nodes.length) return isInline(nodes[0]);
+  if (1 === len) return isInline(nodes[0]);
   
   // Multi-line inline-only tag
   if (this.block.nodes.every(isInline)) {
-    for (var i = 1, len = nodes.length; i < len; ++i) {
+    for (var i = 1; i < len; ++i) {
       if (nodes[i-1].isText && nodes[i].isText)
         return false;
     }


### PR DESCRIPTION
Call nodes.length only once.
