### PR TITLE
swap watchFile for a more cross platform solution

### DIFF
--- a/bin/jade
+++ b/bin/jade
@@ -12,6 +12,7 @@ var fs = require('fs')
   , resolve = path.resolve
   , exists = fs.existsSync || path.existsSync
   , join = path.join
+  , monocle = require('monocle')()
   , mkdirp = require('mkdirp')
   , jade = require('../');
 
@@ -94,10 +95,11 @@ if (files.length) {
   console.log();
   files.forEach(renderFile);
   if (options.watch) {
-    files.forEach(function (file) {
-      fs.watchFile(file, {interval: 100}, function (curr, prev) {
-        if (curr.mtime > prev.mtime) renderFile(file);
-      });
+    monocle.watchFiles({
+      files: files,
+      listener: function(file) {
+        renderFile(file.name);
+      }
     });
   }
   process.on('exit', function () {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "commander": "0.6.1",
     "mkdirp": "0.3.x",
     "transformers": "~1.8.0",
-    "character-parser": "~1.0.0"
+    "character-parser": "~1.0.0",
+    "monocle": "~0.1.43"
   },
   "devDependencies": {
     "coffee-script": "*",


### PR DESCRIPTION
So I know this is a touchy subject but hear me out on this one.

I know many people use jade in this way, whether or not it is the 'best' way to use it is not really up to me to decide. The reality is people do.

So back to the file watcher. As it stands it uses fs.watchFile, which frankly sucks on OSX but is fine on windows. So I offer you my solution, use an external lib which deals with this complexity.

On top of this the lib monocle supports watching folders, so in the future we could add the ability to watch a directory of files. 

Thanks for your time, and your awesome contributions to the OS community. 

:stars: 
