### PR TITLE
if watching and compile failed don't bomb the watch

### DIFF
--- a/bin/jade
+++ b/bin/jade
@@ -146,13 +146,21 @@ function renderFile(path) {
         var dir = resolve(dirname(path));
         mkdirp(dir, 0755, function(err){
           if (err) throw err;
-          var output = options.client
-            ? fn.toString()
-            : fn(options);
-          fs.writeFile(path, output, function(err){
-            if (err) throw err;
-            console.log('  \033[90mrendered \033[36m%s\033[0m', path);
-          });
+          try {
+            var output = options.client
+              ? fn.toString()
+              : fn(options);
+            fs.writeFile(path, output, function(err){
+              if (err) throw err;
+              console.log('  \033[90mrendered \033[36m%s\033[0m', path);
+            });
+          } catch (e) {
+            if (options.watch) {
+              console.error(e.stack || e.message || e);
+            } else {
+              throw e
+            }
+          }
         });
       });
     // Found directory


### PR DESCRIPTION
If we know that someone is watching their files for changes, then we can assume that breaking out of the watch due to a syntax error is undesirable.

Thus a valid assumption would be to show the compile error message while continuing the watch instead of exiting the process.

Thank you for your time.

:water_buffalo: 
