### PR TITLE
added self closing tag option in html5

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -53,6 +53,7 @@ var Compiler = module.exports = function Compiler(node, options) {
   this.hasCompiledDoctype = false;
   this.hasCompiledTag = false;
   this.pp = options.pretty || false;
+  this.sc = options.selfClose || false;
   this.debug = false !== options.compileDebug;
   this.indents = 0;
   this.parentIndents = 0;
@@ -373,7 +374,7 @@ Compiler.prototype = {
     if ((~selfClosing.indexOf(name) || tag.selfClosing) && !this.xml) {
       this.buffer('<' + name);
       this.visitAttributes(tag.attrs);
-      this.terse
+      this.terse && !this.sc
         ? this.buffer('>')
         : this.buffer('/>');
     } else {

--- a/test/jade.test.js
+++ b/test/jade.test.js
@@ -363,6 +363,11 @@ describe('jade', function(){
       assert.equal('<!DOCTYPE html><input type="checkbox">', render('!!! 5\ninput(type="checkbox", checked= false)'));
     });
 
+    it('should support html 5 self-closing tags', function(){
+      assert.equal('<!DOCTYPE html><input type="checkbox" checked/>', render('!!! 5\ninput(type="checkbox", checked)',{selfClose:true}));
+      assert.equal('<!DOCTYPE html><br/><img src="img.jpg"/><dummy/>', render('!!! 5\nbr\nimg(src="img.jpg")\ndummy/',{selfClose:true}));
+    });
+
     it('should support multi-line attrs', function(){
       assert.equal('<a foo="bar" bar="baz" checked="checked">foo</a>', render('a(foo="bar"\n  bar="baz"\n  checked) foo'));
       assert.equal('<a foo="bar" bar="baz" checked="checked">foo</a>', render('a(foo="bar"\nbar="baz"\nchecked) foo'));


### PR DESCRIPTION
Just added the possibility to use self closing tags in html5 as the [W3C working draft](http://dev.w3.org/html5/spec-author-view/syntax.html#syntax-start-tag) describes when using the `selfClose: true` option in the complier.
