### PR TITLE
Add the ability to specify per-filter options. 

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -14,6 +14,7 @@ var nodes = require('./nodes')
   , doctypes = require('./doctypes')
   , selfClosing = require('./self-closing')
   , runtime = require('./runtime')
+  , extend = require('util')._extend
   , utils = require('./utils');
 
 // if browser
@@ -409,7 +410,7 @@ Compiler.prototype = {
     var text = filter.block.nodes.map(
       function(node){ return node.val; }
     ).join('\n');
-    filter.attrs = filter.attrs || {};
+    filter.attrs = extend(this.options.filter && this.options.filter[filter.name] || {}, filter.attrs || {});
     filter.attrs.filename = this.options.filename;
     this.buffer(utils.text(filters(filter.name, text, filter.attrs).replace(/\\/g, '\\\\')));
   },

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -13,6 +13,7 @@ var Lexer = require('./lexer')
   , utils = require('./utils')
   , filters = require('./filters')
   , path = require('path')
+  , extend = require('util')._extend
   , extname = path.extname;
 
 /**
@@ -466,7 +467,7 @@ Parser.prototype = {
       var path = join(dir, path);
       var str = fs.readFileSync(path, 'utf8').replace(/\r/g, '');
       var ext = extname(path).slice(1);
-      if (filters.exists(ext)) str = filters(ext, str, { filename: path });
+      if (filters.exists(ext)) str = filters(ext, str, extend({ filename: path }, this.options.filter && this.options.filter[ext] || {}));
       return new nodes.Literal(str);
     }
 


### PR DESCRIPTION
The idea here is to globally influence options of all uses of some filter through invocation.

My use case is to minify inlined resources (css, js) depending on jade invocation context, rather than .jade source code (ie. makefile and release/debug builds), but there can be others (for example specifying css/xml dialect if some transformer supports that).
