### PR TITLE
Generate Knockout.js virtual elements

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -424,6 +424,21 @@ outputs:
 </head>
 ```
 
+Jade supports generating [Knockout](http://knockoutjs.com/) virtual elements, for example:
+
+```jade
+//ko if: true
+  #test
+```
+
+outputs:
+
+```html
+<!-- ko if: true -->
+<div id="test"></div>
+<!-- /ko -->
+```
+
 <a name="a6-6"/>
 ### Nesting
 

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -454,6 +454,11 @@ Compiler.prototype = {
       this.buffer('<!--[' + comment.val.trim() + ']>');
       this.visit(comment.block);
       this.buffer('<![endif]-->');
+    } else if (0 == comment.val.trim().indexOf('ko')) {
+      this.buffer('<!-- ' + comment.val.trim() + ' -->');
+      this.visit(comment.block);
+      this.buffer('\\n');
+      this.buffer('<!-- /ko -->');
     } else {
       this.buffer('<!--' + comment.val);
       this.visit(comment.block);

--- a/test/cases/comments.knockout.html
+++ b/test/cases/comments.knockout.html
@@ -1,0 +1,3 @@
+<!-- ko if: true -->
+<div id="test"></div>
+<!-- /ko -->

--- a/test/cases/comments.knockout.jade
+++ b/test/cases/comments.knockout.jade
@@ -1,0 +1,3 @@
+
+//ko if: true
+  #test


### PR DESCRIPTION
Add ability to generate [Knockout.js](http://knockoutjs.com/index.html) virtual elements from block comments. For example:

``` jade
//ko if: true
  #test
```

outputs:

``` html
<!-- ko if: true -->
<div id="test"></div>
<!-- /ko -->
```
