### PR TITLE
Stop nested jade renders from clobbering each other.

### DIFF
--- a/lib/jade.js
+++ b/lib/jade.js
@@ -169,9 +169,7 @@ exports.compile = function(str, options){
 
   if (options.client) return new Function('locals', fn)
   fn = new Function('locals, jade', fn)
-  var privateRuntime = {};
-  privateRuntime.__proto__ = runtime;
-  return function(locals){ return fn(locals, privateRuntime) }
+  return function(locals){ return fn(locals, Object.create(runtime)) }
 };
 
 /**


### PR DESCRIPTION
Commit ef156a85bc8 has the side-effect of sharing the runtime variable between nested render calls.

This leads to the exception 'Cannot read property 'filename' of undefined" when one jade render is executed from within another. Before commit ef156a85bc8 this used to work. I assume this happens because the inner render clobbers the debug info for the outer render.

The quickest fix I could come up with is to give each template it's own 'runtime' object to store debug variables in. Maybe there is a better solution?
