### PR TITLE
Check for includes and extensions at root level first.

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -393,7 +393,11 @@ Parser.prototype = {
       throw new Error('the "filename" option is required to extend templates');
 
     var path = this.expect('extends').val.trim();
-    var dir = dirname(this.filename);
+    var dir = "";
+
+    if( !fs.existsSync(join(dir, path + ".jade")) ){
+      dir = dirname(this.filename);
+    }
 
     var path = join(dir, path + '.jade');
     var str = fs.readFileSync(path, 'utf8');
@@ -451,7 +455,11 @@ Parser.prototype = {
     var join = path.join;
 
     var path = this.expect('include').val.trim();
-    var dir = dirname(this.filename);
+    var dir = "";
+
+    if( !fs.existsSync(join(dir, path + ".jade")) ){
+      dir = dirname(this.filename);
+    }
 
     if (!this.filename)
       throw new Error('the "filename" option is required to use includes');


### PR DESCRIPTION
We can now write extensions of base types anywhere without prepending
a whole bunch of ../ action. If no file is found counting from the
cwd (where jade is run from), then it checks for the file relative
to the current .jade file being parsed.

Cleaned up version of https://github.com/visionmedia/jade/pull/978
