### PR TITLE
Only escape ampersands if they aren't the start of an escape seq.

### DIFF
--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -132,7 +132,7 @@ exports.attrs = function attrs(obj, escaped){
 
 exports.escape = function escape(html){
   return String(html)
-    .replace(/&/g, '&amp;')
+    .replace(/&(?!\w+;)/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;');


### PR DESCRIPTION
e.g. &rsquo; now correctly makes it through jade and displays in
browser as a right single quote. An ampsersand on its own will
still be properly escaped.

Uses negative look-ahead in the regex.

Before:
&amp; -> &amp;amp;
& -> &amp;
&rsquo; -> &amp;rsquo;

Now:
&amp; -> &amp;
& -> &amp;
&rsquo; -> &rsquo;
