### PR TITLE
fix watch-compile path

### DIFF
--- a/bin/jade
+++ b/bin/jade
@@ -98,7 +98,8 @@ if (files.length) {
     monocle.watchFiles({
       files: files,
       listener: function(file) {
-        renderFile(file.name);
+        var filename = path.resolve(process.env.PWD, file.fullPath);
+        renderFile(filename);
       }
     });
   }


### PR DESCRIPTION
Give file tree like this:

```
➤➤ tree
.
|-- dir
|   `-- index.jade
`-- index.html
```

or:

```
➤➤ tree
.
|-- dir
|   `-- index.html
`-- index.jade
```

And command `jade --out ./ -wP dir/index.jade` or `jade --out dir/ -wP index.jade`.
The path `monocle` returns is not clear enough and that leads to an error in #974 
I'm using `path.relative` to rewrite the path.
