### PR TITLE
Skip rethrow on client

### DIFF
--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -150,6 +150,7 @@ exports.escape = function escape(html){
 
 exports.rethrow = function rethrow(err, filename, lineno){
   if (!filename) throw err;
+  if (typeof window != 'undefined') throw err;
 
   var context = 3
     , str = require('fs').readFileSync(filename, 'utf8')


### PR DESCRIPTION
Will merge if no complaints by 2013-04-23T16:00:00Z

This skips the rethrow logic on the client, which fixes the problem of it attempting to require `fs` and then read the file.

Supersedes #756
