### PR TITLE
Now preserving case of custom doctypes

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -637,13 +637,13 @@ doctype basic
 it's also possible to simply pass a doctype literal:
 
 ```jade
-doctype html PUBLIC "-//W3C//DTD XHTML Basic 1.1//EN
+doctype html PUBLIC "-//W3C//DTD XHTML Basic 1.1//EN"
 ```
 
 yielding:
 
 ```html
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML Basic 1.1//EN>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML Basic 1.1//EN">
 ```
 
 Below are the doctypes defined by default, which can easily be extended:

--- a/Readme_zh-cn.md
+++ b/Readme_zh-cn.md
@@ -444,11 +444,11 @@ doctypes 是大小写不敏感的, 所以下面两个是一样的:
 
 当然也是可以直接传递一段文档类型的文本：
 
-    doctype html PUBLIC "-//W3C//DTD XHTML Basic 1.1//EN
+    doctype html PUBLIC "-//W3C//DTD XHTML Basic 1.1//EN"
 
 渲染后:
 
-    <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML Basic 1.1//EN>
+    <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML Basic 1.1//EN">
 
 会输出 _html 5_ 文档类型. 下面的默认的文档类型，可以很简单的扩展：
 

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -90,8 +90,8 @@ Compiler.prototype = {
    */
 
   setDoctype: function(name){
-    name = (name && name.toLowerCase()) || 'default';
-    this.doctype = doctypes[name] || '<!DOCTYPE ' + name + '>';
+    name = name || 'default';
+    this.doctype = doctypes[name.toLowerCase()] || '<!DOCTYPE ' + name + '>';
     this.terse = this.doctype.toLowerCase() == '<!doctype html>';
     this.xml = 0 == this.doctype.indexOf('<?xml');
   },

--- a/test/jade.test.js
+++ b/test/jade.test.js
@@ -41,6 +41,7 @@ describe('jade', function(){
       assert.equal('<!DOCTYPE html>', render('!!! html', { doctype:'xml' }));
       assert.equal('<html></html>', render('html'));
       assert.equal('<!DOCTYPE html><html></html>', render('html', { doctype:'html' }));
+      assert.equal('<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML Basic 1.1//EN>', render('doctype html PUBLIC "-//W3C//DTD XHTML Basic 1.1//EN'));
     });
 
     it('should support Buffers', function(){


### PR DESCRIPTION
The doctype is case sensitive in XML files but custom doctypes was mistakenly
made lower case previous to this commit.

Added test case and also updated type in README where doctypes where described.

Currently:

> doctype cross-domain-policy PUBLIC "http://www.macromedia.com/xml/dtds/cross-domain-policy.dtd"

Generates (notice that PUBLIC is made lower case):

> <!DOCTYPE cross-domain-policy system "http://www.macromedia.com/xml/dtds/cross-domain-policy.dtd">

This makes validating XML parsers choke with errors such as "DOCTYPE improperly terminated".

With the pull request the case is preserved and everyone is happy.
