### PR TITLE
Combing through trouble spots with JSHint

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,7 @@
+{
+  "es5": true,
+  "expr": true,
+  "maxerr": 10000,
+  "laxcomma": true,
+  "laxbreak": true
+}


### PR DESCRIPTION
I applied [JSHint](http://jshint.com/) to jade to look for errors. Most were trivial, pre ECMAScript 5 warnings, so I cut them out with `.jshintrc`. The rest may be worth a look:

```
$ jshint .
examples\csrf.js: line 27, col 25, The '__proto__' property is deprecated.

jade.js: line 1, col 241, Missing semicolon.
jade.js: line 1, col 304, Missing semicolon.
jade.js: line 2, col 192, Missing semicolon.
jade.js: line 2, col 284, Missing semicolon.
jade.js: line 2, col 298, Missing semicolon.
jade.js: line 2, col 318, Missing semicolon.
jade.js: line 2, col 404, Missing semicolon.
jade.js: line 36, col 4, Missing semicolon.
jade.js: line 83, col 14, Use '!==' to compare with 'null'.
jade.js: line 109, col 43, Use '===' to compare with 'null'.
jade.js: line 115, col 20, Use '===' to compare with '0'.
jade.js: line 167, col 15, 'context' is already defined.

...

support\benchmark.js: line 41, col 3, Unclosed string.
support\benchmark.js: line 42, col 1, Unclosed string.
support\benchmark.js: line 43, col 40, Unclosed string.
support\benchmark.js: line 44, col 1, Unclosed string.
support\benchmark.js: line 45, col 16, Missing semicolon.
support\benchmark.js: line 45, col 48, Unclosed string.
support\benchmark.js: line 46, col 11, Unclosed string.
support\benchmark.js: line 47, col 12, Unclosed string.
support\benchmark.js: line 48, col 6, Unclosed string.
support\benchmark.js: line 49, col 1, Unclosed string.
support\benchmark.js: line 45, col 21, Missing semicolon.
support\benchmark.js: line 50, col 8, Unexpected '\'.

...

support\benchmark.js: line 121, col 13, Unclosed string.
support\benchmark.js: line 112, col 21, Unclosed string.
support\benchmark.js: line 112, col 21, Missing semicolon.
support\benchmark.js: line 121, col 13, Missing semicolon.
support\benchmark.js: line 19, col 22, Unmatched '{'.

test\jade.test.js: line 66, col 15, 'str' is already defined.
test\jade.test.js: line 72, col 16, 'html' is already defined.
test\jade.test.js: line 80, col 15, 'str' is already defined.
test\jade.test.js: line 86, col 16, 'html' is already defined.
test\jade.test.js: line 165, col 15, 'str' is already defined.

...

test\jade.test.js: line 834, col 16, 'html' is already defined.
test\jade.test.js: line 864, col 15, 'str' is already defined.
test\jade.test.js: line 963, col 34, Missing semicolon.
test\jade.test.js: line 964, col 48, Missing semicolon.
test\jade.test.js: line 965, col 32, Missing semicolon.
test\jade.test.js: line 966, col 41, Missing semicolon.

test\run.js: line 26, col 5, Missing semicolon.

test\unit.js: line 42, col 5, Missing semicolon.
test\unit.js: line 43, col 3, Missing semicolon.

468 errors
```

E.g., missing semicolons can sometimes be stylistic, so I left those alone. But `Unclosed string`s are probably worth fixing.
