### PR TITLE
Do compile time `with` using `with` npm module

### DIFF
--- a/lib/jade.js
+++ b/lib/jade.js
@@ -12,6 +12,7 @@ var Parser = require('./parser')
   , Lexer = require('./lexer')
   , Compiler = require('./compiler')
   , runtime = require('./runtime')
+  , addWith = require('with')
   , fs = require('fs');
 
 /**
@@ -107,7 +108,7 @@ function parse(str, options){
       + 'var buf = [];\n'
       + (options.self
         ? 'var self = locals || {};\n' + js
-        : 'with (locals || {}) {\n' + js + '\n}\n')
+        : addWith('locals || {}', js, ['jade', 'buf'])) + ';'
       + 'return buf.join("");';
   } catch (err) {
     parser = parser.context();

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "mkdirp": "0.3.x",
     "transformers": "~2.0.1",
     "character-parser": "~1.0.2",
-    "monocle": "~0.1.46"
+    "monocle": "~0.1.46",
+    "with": "~1.0.0"
   },
   "devDependencies": {
     "coffee-script": "*",


### PR DESCRIPTION
This has two significant benefits:
1. This makes the resulting code highly optimisable using both minifiers like UglifyJS and JITers in the browsers or node.js
2. This lets you do `if (x)` instead of `if (typeof x != 'undefined' && x)` because all variables are always declared.

It does this by detecting all the "implicit"/undeclared variables in the compiled JavaScript code and declaring them at the top of the module.

The one significant downside is that it slightly more than doubles the size of the client side module due to pulling in the esprima parser.  This doesn't impact the much smaller "runtime.js" and it could alternatively be fixed by using the runtime `with` when on the client.
