### PR TITLE
Remove implicit text-only

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -35,12 +35,6 @@ var Parser = exports = module.exports = function Parser(str, filename, options){
 };
 
 /**
- * Tags that may not contain tags.
- */
-
-var textOnly = exports.textOnly = ['script', 'style'];
-
-/**
  * Parser prototype.
  */
 
@@ -682,20 +676,6 @@ Parser.prototype = {
 
     // newline*
     while ('newline' == this.peek().type) this.advance();
-
-    tag.textOnly = tag.textOnly || ~textOnly.indexOf(tag.name);
-
-    // script special-case
-    if ('script' == tag.name) {
-      var type = tag.getAttribute('type');
-      if (!dot && type && 'text/javascript' != type.replace(/^['"]|['"]$/g, '')) {
-        tag.textOnly = false;
-      }
-    }
-
-    if (tag.textOnly && !dot && !(tag.name == 'script' && tag.getAttribute('src'))) {
-      console.warn('Implicit textOnly for `script` and `style` is deprecated.  Use `script.` or `style.` instead.');
-    }
 
     // block?
     if ('indent' == this.peek().type) {


### PR DESCRIPTION
This forces people to add the `.` if they want text only.  This is not to be merged until a future version as people need time to be notified of the deprecated feature.
