### PR TITLE
Upgrade "with" module to 1.0.3.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "transformers": "2.0.1",
     "character-parser": "1.0.2",
     "monocle": "0.1.46",
-    "with": "1.0.0"
+    "with": "1.0.3"
   },
   "devDependencies": {
     "coffee-script": "*",


### PR DESCRIPTION
Your [last commit](https://github.com/visionmedia/jade/commit/939bf3fe1e79f1ec15c3f385214f510567f30b71) broke the tests by switching to `with` version 1.0.0. They probably fixed some bug between 1.0.0 and 1.0.3; upgrading fixes all the failing tests.
