### PR TITLE
Custom Parser Override

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -419,8 +419,6 @@ Parser.prototype = {
     if ('.jade' != path.substr(-5)) path += '.jade';
 
     var str = fs.readFileSync(path, 'utf8');
-	//MODIFIED MPP 20130523 for custom parser override
-	// ref: https://github.com/visionmedia/jade/commit/e4b0fd6a357948055c80c7f1535db70396277565
     var parser = new (this.options.parser || Parser)(str, path, this.options);
 
     parser.blocks = this.blocks;
@@ -488,8 +486,6 @@ Parser.prototype = {
     }
 
     var str = fs.readFileSync(path, 'utf8');
-	//MODIFIED MPP 20130523 for custom parser override
-	// ref: https://github.com/visionmedia/jade/commit/e4b0fd6a357948055c80c7f1535db70396277565
     var parser = new (this.options.parser || Parser)(str, path, this.options);
     parser.blocks = utils.merge({}, this.blocks);
 


### PR DESCRIPTION
This commit expands on pull request:
https://github.com/visionmedia/jade/pull/1017
To allow for a custom parser override.  However, since the parser itself instantiates new Parsers, the change from pull request by@sax1johno must also be brought into parser.js to fully allow for a custom parser override.

ref: https://github.com/visionmedia/jade/commit/e4b0fd6a357948055c80c7f1535db70396277565
