### PR TITLE
Change dotless textOnly deprecation warning to only warn for blocks

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -693,8 +693,6 @@ Parser.prototype = {
       }
     }
 
-
-
     // block?
     if ('indent' == this.peek().type) {
       if (tag.textOnly) {


### PR DESCRIPTION
Fix for some of the false deprecation warnings that have come up in #1036
