### PR TITLE
Watch child files when using `-w`

### DIFF
--- a/bin/jade
+++ b/bin/jade
@@ -95,8 +95,9 @@ if (files.length) {
   console.log();
   files.forEach(renderFile);
   if (options.watch) {
-    monocle.watchFiles({
-      files: files,
+    monocle.watchPathes({
+      path: files,
+      fileFilter: '*.jade',
       listener: function(file) {
         renderFile(file.absolutePath);
       }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "mkdirp": "0.3.x",
     "transformers": "2.0.1",
     "character-parser": "1.0.2",
-    "monocle": "0.1.48",
+    "monocle": "0.1.50",
     "with": "1.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Monocle added a new API for watching pathes: https://github.com/samccone/monocle/pull/16
I tested on Linux, hope it works on all platforms and fix this issue: https://github.com/visionmedia/jade/issues/994
