### PR TITLE
Add a dot after script tag

### DIFF
--- a/src/pages/index.jade
+++ b/src/pages/index.jade
@@ -10,7 +10,7 @@ block content
           html(lang="en")
             head
               title= pageTitle
-              script(type='text/javascript')
+              script(type='text/javascript').
                 if (foo) {
                    bar()
                 }


### PR DESCRIPTION
Implicit textOnly for `script` and `style` is deprecated.  Use `script.` or `style.` instead.
