### PR TITLE
Use constantinople to handle detecting constants

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -15,6 +15,8 @@ var nodes = require('./nodes')
   , runtime = require('./runtime')
   , utils = require('./utils')
   , parseJSExpression = require('character-parser').parseMax
+  , isConstant = require('constantinople')
+  , toConstant = require('constantinople').toConstant
 
 
 /**
@@ -135,6 +137,9 @@ Compiler.prototype = {
    */
 
   bufferExpression: function (src) {
+    if (isConstant(src)) {
+      return this.buffer(toConstant(src), false)
+    }
     if (this.lastBufferedIdx == this.buf.length) {
       if (this.lastBufferedType === 'text') this.lastBuffered += '"';
       this.lastBufferedType = 'code';
@@ -595,8 +600,7 @@ Compiler.prototype = {
       this.bufferExpression("jade.attrs(jade.merge({ " + val.buf +
           " }, attributes), jade.merge(" + val.escaped + ", escaped, true))");
     } else if (val.constant) {
-      eval('var buf={' + val.buf + '};');
-      this.buffer(runtime.attrs(buf, JSON.parse(val.escaped)));
+      this.buffer(runtime.attrs(toConstant('{' + val.buf + '}'), JSON.parse(val.escaped)));
     } else {
       this.bufferExpression("jade.attrs({ " + val.buf + " }, " + val.escaped + ")");
     }
@@ -638,28 +642,3 @@ Compiler.prototype = {
     };
   }
 };
-
-/**
- * Check if expression can be evaluated to a constant
- *
- * @param {String} expression
- * @return {Boolean}
- * @api private
- */
-
-function isConstant(val){
-  // Check strings/literals
-  if (/^ *("([^"\\]*(\\.[^"\\]*)*)"|'([^'\\]*(\\.[^'\\]*)*)'|true|false|null|undefined) *$/i.test(val))
-    return true;
-
-  // Check numbers
-  if (!isNaN(Number(val)))
-    return true;
-
-  // Check arrays
-  var matches;
-  if (matches = /^ *\[(.*)\] *$/.exec(val))
-    return matches[1].split(',').every(isConstant);
-
-  return false;
-}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "transformers": "2.0.1",
     "character-parser": "1.0.2",
     "monocle": "0.1.48",
-    "with": "~1.1.0"
+    "with": "~1.1.0",
+    "constantinople": "~1.0.1"
   },
   "devDependencies": {
     "coffee-script": "*",


### PR DESCRIPTION
This uses [constantinople](https://github.com/ForbesLindesay/constantinople) to detect what is and isn't constant.  This has the huge advantage of allowing a lot more things to be constant, for example, you could do basic maths:

``` jade
div(width= (0.3 * 1024) + 'px')
```

It uses `UglifyJS` which is the same parser that is required by `with` and minification within `transformers` so the extra dependency adds very little additional download weight.

If no issues are raised, I will merge after 2013-06-26T23:00:00Z
