### PR TITLE
Update parser to allow easier inheritance of Parser object for custom functionality

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -47,10 +47,10 @@ var textOnly = exports.textOnly = ['script', 'style'];
 Parser.prototype = {
 
   /**
-   * Save original prototype constructor
+   * Save original constructor
    */
 
-  constructor: Parser.prototype.constructor,
+  constructor: Parser,
 
   /**
    * Push `parser` onto the context stack,


### PR DESCRIPTION
For my express.js project, I needed to inherit from the parser object to override the resolvePath method.

I found that the original resolvePath method was being called when the extends and include commands were nested across multiple templates.

This is because the parseExtends and parseInclude methods call the base Parser constructor to recursively parse the template referenced by the command. If this template then contains another extend or include command, the original resolvePath method is called instead of the overriding version. This causes the code to fail.

I was able to work-around the problem, by also overriding the parseExtends and parseInclude methods, but it was not a very satisfactory solution, because I had to copy out the code, replacing only the constructor call.

The following minimal modifications allow to correctly use the original parseExtends and parseInclude methods in the inheriting parser.
