### PR TITLE
Block comments should have spacing in pretty print as well

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -494,9 +494,11 @@ Compiler.prototype = {
 
   visitBlockComment: function(comment){
     if (!comment.buffer) return;
+    if (this.pp) this.prettyIndent(1, true);
     if (0 == comment.val.trim().indexOf('if')) {
       this.buffer('<!--[' + comment.val.trim() + ']>');
       this.visit(comment.block);
+      if (this.pp) this.prettyIndent(1, true);
       this.buffer('<![endif]-->');
     } else {
       this.buffer('<!--' + comment.val);


### PR DESCRIPTION
Fixes #1122. Block comments weren't getting proper spacing when pretty pring was selected
