### PR TITLE
Support `//.` denoting a text only block comment

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -325,7 +325,13 @@ Parser.prototype = {
     var node;
 
     if ('indent' == this.peek().type) {
-      node = new nodes.BlockComment(tok.val, this.block(), tok.buffer);
+      if (tok.val === '.') {
+        this.lexer.pipeless = true;
+        node = new nodes.BlockComment('', this.parseTextBlock(), tok.buffer);
+        this.lexer.pipeless = false;
+      } else {
+        node = new nodes.BlockComment(tok.val, this.block(), tok.buffer);
+      }
     } else {
       node = new nodes.Comment(tok.val, tok.buffer);
     }

--- a/test/cases/comments.html
+++ b/test/cases/comments.html
@@ -27,3 +27,5 @@
 <!-- end-inline-->
 <![endif]-->
 <p>five</p>
+<!--This is just a plain text block comment
+-->

--- a/test/cases/comments.jade
+++ b/test/cases/comments.jade
@@ -25,3 +25,6 @@ ul
   // end-inline
 
 p five
+
+//.
+  This is just a plain text block comment


### PR DESCRIPTION
[closes #1134]

This adds the ability to have text only block comments using `.` just like after tags e.g.

``` jade
//.
  User: Pu
  Date: 6/2/13
  Time: 4:13 PM
```

would compile to

``` html
<!--User: Pu
Date: 6/2/13
Time: 4:13 PM-->
```

I'd like to hear people's thoughts before I propose merging this.  Is there a better way of implementing this?  Are there any suggestions for better syntax?
