### PR TITLE
Fix homepage sample to use explicit text mode with "."

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <span class="tag">html</span>(<span class="attribute">lang</span>=<span class="string">"en"</span>)
   <span class="tag">head</span>
     <span class="tag">title</span>= pageTitle
-    <span class="tag">script</span>(<span class="attribute">type</span>=<span class="string">'text/javascript'</span>)
+    <span class="tag">script</span>(<span class="attribute">type</span>=<span class="string">'text/javascript'</span>).
       <span class="keyword">if</span> (foo) {
          <span class="tag">bar</span>()
       }


### PR DESCRIPTION
This updates the homepage sample to reflect deprecation of implicit text-only support for script tags since Jade 0.31.0
