### PR TITLE
Fix escaping of data-* attributes [closes #1075]

### DIFF
--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -118,7 +118,7 @@ exports.attrs = function attrs(obj, escaped){
             : buf.push(key + '="' + key + '"');
         }
       } else if (0 == key.indexOf('data') && 'string' != typeof val) {
-        buf.push(key + "='" + JSON.stringify(val) + "'");
+        buf.push(key + "='" + JSON.stringify(val).replace(/'/g, '&apos;') + "'");
       } else if ('class' == key) {
         if (escaped && escaped[key]){
           if (val = exports.escape(joinClasses(val))) {

--- a/test/cases/attrs-data.html
+++ b/test/cases/attrs-data.html
@@ -1,3 +1,4 @@
 <foo data-user='{"name":"tobi"}'></foo>
 <foo data-items='[1,2,3]'></foo>
 <foo data-username="tobi"></foo>
+<foo data-escaped='{"message":"Let&apos;s rock!"}'></foo>

--- a/test/cases/attrs-data.jade
+++ b/test/cases/attrs-data.jade
@@ -2,3 +2,4 @@ user = { name: 'tobi' }
 foo(data-user=user)
 foo(data-items=[1,2,3])
 foo(data-username='tobi')
+foo(data-escaped={message: "Let's rock!"})


### PR DESCRIPTION
When objects are used as values for `data-` attributes,
the stringified JSON is delimited by single quotes,
so these must be replaced with HTML character entity references.
