### PR TITLE
Fixes typo in tutorial.

### DIFF
--- a/src/pages/tutorial.jade
+++ b/src/pages/tutorial.jade
@@ -6,7 +6,7 @@ block content
 
     h3 Introduction
     p.
-      This tutorial is a work in progress. Once it's finished it will become a fully row getting started guide.
+      This tutorial is a work in progress. Once it's finished it will become a fully grown getting started guide.
     p.
       Welcolme to the Jade templating engine.  Jade is designed primarily for server side templating in node.js, however it can be used in many other environments.  It is only intended to produce XML like documents (HTML, RSS etc.) so don't use it to create plain text/markdown/CSS/whatever documents.
     p.


### PR DESCRIPTION
I'm guessing it's supposed to say "fully grown getting started guide" not "fully row getting started guide," so I changed it to that.
