### PR TITLE
Made empty unescaped attribute names consistent with regular attributes

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -568,6 +568,7 @@ Lexer.prototype = {
                 val = val.trim();
                 key = key.trim();
                 if ('' == key) return;
+                if ('!' == key && !escapedAttr) return;
                 key = key.replace(/^['"]|['"]$/g, '').replace('!', '');
                 tok.escaped[key] = escapedAttr;
                 tok.attrs[key] = '' == val


### PR DESCRIPTION
Fixes this inconsistency:

``` jade
div(=)
div(!=)
```

``` html
<div></div><div =""></div>
```
