### PR TITLE
Add file extension for files containing a dot

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -406,7 +406,7 @@ Parser.prototype = {
 
     path = join(path[0] === '/' ? this.options.basedir : dirname(this.filename), path);
 
-    if (basename(path).indexOf('.') === -1) path += '.jade';
+    if (!basename(path).match(/\.jade$/)) path += '.jade';
 
     return path;
   },


### PR DESCRIPTION
Currently it wont add extension if filename contains a dot,
so compiling `foo.bar.jade` template does not work.

Consider compiling `foo.jade` template which contains `include ./foo.bar` statement.
It is of course "fixable" by using `include ./foo.bar.jade` but this way templates becomes hairy.
