### PR TITLE
optional indentChar implementation

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -33,6 +33,7 @@ var Compiler = module.exports = function Compiler(node, options) {
   this.hasCompiledDoctype = false;
   this.hasCompiledTag = false;
   this.pp = options.pretty || false;
+  this.indentChar = options.indentChar || '  ';
   this.debug = false !== options.compileDebug;
   this.inMixin = false;
   this.indents = 0;
@@ -168,7 +169,7 @@ Compiler.prototype = {
   prettyIndent: function(offset, newline){
     offset = offset || 0;
     newline = newline ? '\n' : '';
-    this.buffer(newline + Array(this.indents + offset).join('  '));
+    this.buffer(newline + Array(this.indents + offset).join(this.indentChar));
     if (this.parentIndents)
       this.buf.push("buf.push.apply(buf, jade.indent);");
   },


### PR DESCRIPTION
Select your most beloved indent char to be used in pretty output.
Indentation defaults to two spaces.

If you want to indent your code with a tab just add 

```
app.locals.pretty = true;
app.locals.indentChar = "\t";
```
