### PR TITLE
Ability to track files used to compile a template

### DIFF
--- a/lib/jade.js
+++ b/lib/jade.js
@@ -109,6 +109,7 @@ function parse(str, options){
         ? 'var self = locals || {};\n' + js
         : addWith('locals || {}', js, globals)) + ';'
       + 'return buf.join("");';
+    return [fnStr,parser.files];
   } catch (err) {
     parser = parser.context();
     runtime.rethrow(err, parser.filename, parser.lexer.lineno, parser.input);
@@ -140,22 +141,27 @@ exports.compile = function(str, options){
 
   str = String(str);
 
+  var parseResult = parse(str, options);
+  fn = parseResult[0];
   if (options.compileDebug !== false) {
     fn = [
         'jade.debug = [{ lineno: 1, filename: ' + filename + ' }];'
       , 'try {'
-      , parse(str, options)
+      , fn
       , '} catch (err) {'
       , '  jade.rethrow(err, jade.debug[0].filename, jade.debug[0].lineno' + (options.compileDebug === true ? ',' + JSON.stringify(str) : '') + ');'
       , '}'
     ].join('\n');
-  } else {
-    fn = parse(str, options);
   }
 
   if (options.client) return new Function('locals', fn)
   fn = new Function('locals, jade', fn)
-  return function(locals){ return fn(locals, Object.create(runtime)) }
+  var fn2 = function(locals){ return fn(locals, Object.create(runtime)) };
+  if(options.filename) {
+    fn2.files = {};
+    fn2.files[options.filename] = parseResult[1];
+  }
+  return fn2;
 };
 
 /**

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -31,6 +31,7 @@ var Parser = exports = module.exports = function Parser(str, filename, options){
   this.filename = filename;
   this.blocks = {};
   this.mixins = {};
+  this.files = {};
   this.options = options;
   this.contexts = [this];
 };
@@ -435,6 +436,7 @@ Parser.prototype = {
     parser.blocks = this.blocks;
     parser.contexts = this.contexts;
     this.extending = parser;
+    this.files[path] = parser.files;
 
     // TODO: null node
     return new nodes.Literal('');
@@ -496,6 +498,7 @@ Parser.prototype = {
     // non-jade
     if ('.jade' != path.substr(-5)) {
       var str = fs.readFileSync(path, 'utf8').replace(/\r/g, '');
+      this.files[path] = {};
       var ext = extname(path).slice(1);
       if (filters.exists(ext)) str = filters(ext, str, { filename: path });
       return new nodes.Literal(str);
@@ -509,6 +512,7 @@ Parser.prototype = {
 
     this.context(parser);
     var ast = parser.parse();
+    this.files[path] = parser.files;
     this.context();
     ast.filename = path;
 


### PR DESCRIPTION
I'm working on a piece of middleware that will dynamically compile jade templates to static html and invalidate that html whenever any file used in the compiling the template changes (i.e. extends and includes). Sort of what stylus is for css for jade/html. (wip: https://github.com/sdether/jaded)

In order to do the cache invalidation, i need to know what files make up a compiled template. Since compile only returns a function, I've attached the tree of files i recursively gathered in the parser to the function as a property, which may not be the most elegant way. If you'd prefer I create a new API entry-point that returns an object containing both the compiled function and the file tree, let me know and I'll re-work this.
