### PR TITLE
Remove support for parsed & conditional comments

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -507,17 +507,10 @@ Compiler.prototype = {
   visitBlockComment: function(comment){
     if (!comment.buffer) return;
     if (this.pp) this.prettyIndent(1, true);
-    if (0 == comment.val.trim().indexOf('if')) {
-      this.buffer('<!--[' + comment.val.trim() + ']>');
-      this.visit(comment.block);
-      if (this.pp) this.prettyIndent(1, true);
-      this.buffer('<![endif]-->');
-    } else {
-      this.buffer('<!--' + comment.val);
-      this.visit(comment.block);
-      if (this.pp) this.prettyIndent(1, true);
-      this.buffer('-->');
-    }
+    this.buffer('<!--' + comment.val);
+    this.visit(comment.block);
+    if (this.pp) this.prettyIndent(1, true);
+    this.buffer('-->');
   },
 
   /**

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -333,7 +333,9 @@ Parser.prototype = {
     var node;
 
     if ('indent' == this.peek().type) {
-      node = new nodes.BlockComment(tok.val, this.block(), tok.buffer);
+      this.lexer.pipeless = true;
+      node = new nodes.BlockComment(tok.val, this.parseTextBlock(), tok.buffer);
+      this.lexer.pipeless = false;
     } else {
       node = new nodes.Comment(tok.val, tok.buffer);
     }

--- a/test/cases/comments.conditional.html
+++ b/test/cases/comments.conditional.html
@@ -1,4 +1,0 @@
-
-<!--[if IE lt 9]>
-<script src="/lame.js"></script>
-<![endif]-->

--- a/test/cases/comments.conditional.jade
+++ b/test/cases/comments.conditional.jade
@@ -1,2 +1,0 @@
-//if IE lt 9
-  script(src='/lame.js')

--- a/test/cases/comments.html
+++ b/test/cases/comments.html
@@ -7,23 +7,25 @@
   <li>two</li>
 </ul>
 <!--
-<ul>
-  <li>foo</li>
-</ul>
+ul
+  li foo
+  
 -->
 <!-- block
-<!-- inline follow-->
-<li>three</li>
+// inline follow
+li three
+
 -->
 <!-- block
-<!-- inline followed by tags-->
-<ul>
-  <li>four</li>
-</ul>
+// inline followed by tags
+ul
+  li four
+  
 -->
-<!--[if IE lt 9]>
-<!-- inline-->
-<script src="/lame.js"></script>
-<!-- end-inline-->
-<![endif]-->
+<!--if IE lt 9
+// inline
+script(src='/lame.js')
+// end-inline
+
+-->
 <p>five</p>


### PR DESCRIPTION
Parsing non-conditional comments is really confusing and unexpected, we need to stop doing it.

Supporting conditional comments to the extent people want is impossible.  They are largely an anti-pattern as there is almost always a better way to do the same thing.  In the rare case that you do need a conditional comment they can be written inline and will work just fine:

``` jade
<!--[if IE lt 9]>
script(src="/lame.js")
<![endif]-->
```

We should just tell people to write their conditional comments like that.

Closes #931 Closes #487 Closes #1135 Closes #1134 Closes #1178
