### PR TITLE
Added resolve() api entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ var html = jade.render('string of jade', merge(options, locals));
 
 // renderFile
 var html = jade.renderFile('filename.jade', merge(options, locals));
+
+// resolve
+var info = jade.resolve('string of jade', options);
+var html = info.fn(locals);
+var dependencies = info.dependencies;
 ```
 
 ### Options

--- a/lib/jade.js
+++ b/lib/jade.js
@@ -80,7 +80,7 @@ exports.cache = {};
  *
  * @param {String} str
  * @param {Object} options
- * @return {String}
+ * @return {Object} parse results;
  * @api private
  */
 
@@ -104,17 +104,93 @@ function parse(str, options){
     globals.push('jade_debug');
     globals.push('buf');
 
-    return ''
+    var parsed = ''
       + 'var buf = [];\n'
       + (options.self
         ? 'var self = locals || {};\n' + js
         : addWith('locals || {}', js, globals)) + ';'
       + 'return buf.join("");';
+    return {
+      parsed: parsed,
+      dependencies: parser.files,
+      source: str
+    };
   } catch (err) {
     parser = parser.context();
     runtime.rethrow(err, parser.filename, parser.lexer.lineno, parser.input);
   }
 }
+
+/**
+ * Compile the function body created by `parse` into a function.
+ *
+ * @param {Object} parseResult
+ * @param {Object} options
+ * @returns {Function}
+ * @api private
+ */
+function compile(parseResult, options) {
+  var fn
+    , filename = options.filename
+      ? JSON.stringify(options.filename)
+      : 'undefined';
+  if (options.compileDebug !== false) {
+    fn = [
+        'var jade_debug = [{ lineno: 1, filename: ' + filename + ' }];'
+      , 'try {'
+      , parseResult.parsed
+      , '} catch (err) {'
+      , '  jade.rethrow(err, jade_debug[0].filename, jade_debug[0].lineno' + (options.compileDebug === true ? ',' + JSON.stringify(parseResult.source) : '') + ');'
+      , '}'
+    ].join('\n');
+  } else {
+    fn = parseResult.parsed;
+  }
+
+  if (options.client) return new Function('locals', fn)
+  fn = new Function('locals, jade', fn)
+  return function(locals){ return fn(locals, Object.create(runtime)) }
+}
+
+/**
+ * Resolve dependencies of a given jade 'str'.
+ *
+ * Info:
+ *
+ *    - `dependencies` A tree of template filenames and their dependendent
+        filenames. If `options.filename` is specified the tree is rooted at
+        that filename.
+ *    - `fn` the compiled function otherwise returned by `compile`.
+ *
+ * Options:
+ *
+ *   - `compileDebug` when `false` debugging code is stripped from the compiled
+        template, when it is explicitly `true`, the source code is included in
+        the compiled template for better accuracy.
+ *   - `filename` used to improve errors when `compileDebug` is not `false`
+ *
+ * @param {String} str
+ * @param {Options} options
+ * @returns {Info}
+ * @api public
+ */
+exports.resolve = function(str, options) {
+  options = options || {};
+
+  str = String(str);
+
+  var parseResult = parse(str, options);
+  var info = {
+    fn: compile(parseResult, options)
+  };
+  if( options.filename ) {
+    info.dependencies = {};
+    info.dependencies[options.filename] = parseResult.dependencies;
+  } else {
+    info.dependencies = parseResult.dependencies
+  }
+  return info;
+};
 
 /**
  * Compile a `Function` representation of the given jade `str`.
@@ -133,30 +209,12 @@ function parse(str, options){
  */
 
 exports.compile = function(str, options){
-  var options = options || {}
-    , filename = options.filename
-      ? JSON.stringify(options.filename)
-      : 'undefined'
-    , fn;
+  options = options || {};
 
   str = String(str);
 
-  if (options.compileDebug !== false) {
-    fn = [
-        'var jade_debug = [{ lineno: 1, filename: ' + filename + ' }];'
-      , 'try {'
-      , parse(str, options)
-      , '} catch (err) {'
-      , '  jade.rethrow(err, jade_debug[0].filename, jade_debug[0].lineno' + (options.compileDebug === true ? ',' + JSON.stringify(str) : '') + ');'
-      , '}'
-    ].join('\n');
-  } else {
-    fn = parse(str, options);
-  }
-
-  if (options.client) return new Function('locals', fn)
-  fn = new Function('locals, jade', fn)
-  return function(locals){ return fn(locals, Object.create(runtime)) }
+  var parseResult = parse(str, options);
+  return compile(parseResult, options);
 };
 
 /**

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -31,6 +31,7 @@ var Parser = exports = module.exports = function Parser(str, filename, options){
   this.filename = filename;
   this.blocks = {};
   this.mixins = {};
+  this.files = {};
   this.options = options;
   this.contexts = [this];
 };
@@ -434,6 +435,7 @@ Parser.prototype = {
     parser.blocks = this.blocks;
     parser.contexts = this.contexts;
     this.extending = parser;
+    this.files[path] = parser.files;
 
     // TODO: null node
     return new nodes.Literal('');
@@ -495,6 +497,7 @@ Parser.prototype = {
     // non-jade
     if ('.jade' != path.substr(-5)) {
       var str = fs.readFileSync(path, 'utf8').replace(/\r/g, '');
+      this.files[path] = {};
       var ext = extname(path).slice(1);
       if (filters.exists(ext)) str = filters(ext, str, { filename: path });
       return new nodes.Literal(str);
@@ -508,6 +511,7 @@ Parser.prototype = {
 
     this.context(parser);
     var ast = parser.parse();
+    this.files[path] = parser.files;
     this.context();
     ast.filename = path;
 

--- a/test/dependencies/dependency1.jade
+++ b/test/dependencies/dependency1.jade
@@ -1,0 +1,1 @@
+strong dependency1

--- a/test/dependencies/dependency2.jade
+++ b/test/dependencies/dependency2.jade
@@ -1,0 +1,1 @@
+include dependency3

--- a/test/dependencies/dependency3.jade
+++ b/test/dependencies/dependency3.jade
@@ -1,0 +1,1 @@
+strong dependency3

--- a/test/dependencies/extends1.jade
+++ b/test/dependencies/extends1.jade
@@ -1,0 +1,1 @@
+extends dependency1

--- a/test/dependencies/extends2.jade
+++ b/test/dependencies/extends2.jade
@@ -1,0 +1,1 @@
+extends dependency2

--- a/test/dependencies/include1.jade
+++ b/test/dependencies/include1.jade
@@ -1,0 +1,1 @@
+include dependency1

--- a/test/dependencies/include2.jade
+++ b/test/dependencies/include2.jade
@@ -1,0 +1,1 @@
+include dependency2

--- a/test/jade.test.js
+++ b/test/jade.test.js
@@ -21,6 +21,61 @@ describe('jade', function(){
     });
   });
 
+  describe('.resolve()', function() {
+    it('should return the same function as compile as part of its output', function() {
+      var str = [
+        'p',
+        '  strong testing 1..2..3..',
+      ].join('\r\n');
+      var fn1 = jade.resolve(str).fn;
+      var fn2 = jade.compile(str);
+      assert.equal(fn1(str),fn2(str));
+    });
+    it('should list the filename of the template referenced by extends', function(){
+      var filename = __dirname+"/dependencies/extends1.jade";
+      var str = fs.readFileSync(filename, 'utf8');
+      var info = jade.resolve(str,{filename:filename});
+      var dependencies = {};
+      var childDependencies = {};
+      childDependencies[__dirname+"/dependencies/dependency1.jade"] = {};
+      dependencies[filename] = childDependencies;
+      assert.deepEqual(dependencies,info.dependencies);
+    });
+    it('should list the filename of the template referenced by an include', function() {
+      var filename = __dirname+"/dependencies/include1.jade";
+      var str = fs.readFileSync(filename, 'utf8');
+      var info = jade.resolve(str,{filename:filename});
+      var dependencies = {};
+      var childDependencies = {};
+      childDependencies[__dirname+"/dependencies/dependency1.jade"] = {};
+      dependencies[filename] = childDependencies;
+      assert.deepEqual(dependencies,info.dependencies);
+    });
+    it('should list the dependencies of extends dependencies', function() {
+      var filename = __dirname+"/dependencies/extends2.jade";
+      var str = fs.readFileSync(filename, 'utf8');
+      var info = jade.resolve(str,{filename:filename});
+      var dependencies = {};
+      var child1Deps = {};
+      var child2Deps = {};
+      child2Deps[__dirname+"/dependencies/dependency3.jade"] = {};
+      child1Deps[__dirname+"/dependencies/dependency2.jade"] = child2Deps;
+      dependencies[filename] = child1Deps;
+      assert.deepEqual(dependencies,info.dependencies);
+    });
+    it('should list the dependencies of include dependencies', function() {
+      var filename = __dirname+"/dependencies/include2.jade";
+      var str = fs.readFileSync(filename, 'utf8');
+      var info = jade.resolve(str,{filename:filename});
+      var dependencies = {};
+      var child1Deps = {};
+      var child2Deps = {};
+      child2Deps[__dirname+"/dependencies/dependency3.jade"] = {};
+      child1Deps[__dirname+"/dependencies/dependency2.jade"] = child2Deps;
+      dependencies[filename] = child1Deps;
+      assert.deepEqual(dependencies,info.dependencies);
+    });
+  });
   describe('.compile()', function(){
     it('should support doctypes', function(){
       assert.equal('<?xml version="1.0" encoding="utf-8" ?>', jade.render('!!! xml'));


### PR DESCRIPTION
Added resolve() api to compile a template and resolve it's dependency tree of template files used to generate that function.

The purpose of this addition is to allow staleness checking on generated output from jade, since just checking the modification of the template file itself may not indicate that one of its dependencies (either through `extends` or `include` has changed). I'm using this functionality in https://github.com/sdether/connect-jaded, a piece of middleware that, like stylus does for css, lets you write your static content in jade rather than html, but still serve static html for performance and caching reasons.

The added syntax is:

```
jade.resolve('str',options) => 
{
  fn: [compiled function],
  dependencies: {
    [filepath]: {
      [include1path]: {},
      [include2path]: {
        [subinclude1path]: {}
      }
    }
  }
}
```

Also added the following tests:

```
  jade
    .resolve()
      ✓ should return the same function as compile as part of its output
      ✓ should list the filename of the template referenced by extends
      ✓ should list the filename of the template referenced by an include
      ✓ should list the dependencies of extends dependencies
      ✓ should list the dependencies of include dependencies
```
