### PR TITLE
Make filtering of include explicit

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -377,6 +377,23 @@ Lexer.prototype = {
   },
 
   /**
+   * Include with filter
+   */
+  
+  includeFiltered: function() {
+    var captures;
+    if (captures = /^include:([a-zA-Z0-9\-]+) +([^\n]+)/.exec(this.input)) {
+      this.consume(captures[0].length);
+      console.dir(captures);
+      var filter = captures[1];
+      var path = captures[2];
+      var tok = this.tok('include', path);
+      tok.filter = filter;
+      return tok;
+    }
+  },
+
+  /**
    * Case.
    */
   
@@ -440,7 +457,7 @@ Lexer.prototype = {
           //not a bracket expcetion, just unmatched open parens
         }
       }
-      
+
       return tok;
     }
   },
@@ -806,6 +823,7 @@ Lexer.prototype = {
       || this.block()
       || this.mixinBlock()
       || this.include()
+      || this.includeFiltered()
       || this.mixin()
       || this.call()
       || this.conditional()

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -491,14 +491,20 @@ Parser.prototype = {
 
   parseInclude: function(){
     var fs = require('fs');
+    var tok = this.expect('include');
 
-    var path = this.resolvePath(this.expect('include').val.trim(), 'include');
+    var path = this.resolvePath(tok.val.trim(), 'include');
+
+    // has-filter
+    if (tok.filter) {
+      var str = fs.readFileSync(path, 'utf8').replace(/\r/g, '');
+      str = filters(tok.filter, str, { filename: path });
+      return new nodes.Literal(str);
+    }
 
     // non-jade
     if ('.jade' != path.substr(-5)) {
       var str = fs.readFileSync(path, 'utf8').replace(/\r/g, '');
-      var ext = extname(path).slice(1);
-      if (filters.exists(ext)) str = filters(ext, str, { filename: path });
       return new nodes.Literal(str);
     }
 

--- a/test/cases/include-filter-stylus.jade
+++ b/test/cases/include-filter-stylus.jade
@@ -1,1 +1,1 @@
-include some.styl
+include:styl some.styl

--- a/test/cases/include-filter.jade
+++ b/test/cases/include-filter.jade
@@ -1,3 +1,3 @@
 html
   body
-    include some.md
+    include:md some.md

--- a/test/cases/includes-with-ext-js.html
+++ b/test/cases/includes-with-ext-js.html
@@ -1,6 +1,2 @@
-<html>
-  <body><script type="text/javascript">
-var x = "\n here is some \n new lined text";
-</script>
-  </body>
-</html>
+<pre><code>var x = "\n here is some \n new lined text";
+</code></pre>

--- a/test/cases/includes-with-ext-js.jade
+++ b/test/cases/includes-with-ext-js.jade
@@ -1,3 +1,3 @@
-html
-  body
+pre
+  code
     include javascript-new-lines.js

--- a/test/cases/includes.jade
+++ b/test/cases/includes.jade
@@ -6,4 +6,4 @@ include auxiliary/mixins
 body
   include auxiliary/smile.html
   include auxiliary/escapes.html
-  include auxiliary/includable.js
+  include:js auxiliary/includable.js


### PR DESCRIPTION
This adds the syntax:

``` jade
include:filter-name path/to/file.ext
```

It also means that if you had:

``` jade
include foo.js
```

before and expect it to carry on adding `<script>` tags, you will need to switch to either:

``` jade
include:js foo.js
```

or

``` jade
script
  include foo.js
```
