### PR TITLE
Client option documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ var html = jade.renderFile('filename.jade', merge(options, locals));
 
  - `filename`  Used in exceptions, and required when using includes
  - `compileDebug`  When `false` no debug instrumentation is compiled
+ - `client` Render javascript to be used browser (client) side (see [browser support](#browser-support) below)
  - `pretty`    Add pretty-indentation whitespace to output _(false by default)_
 
 ## Browser Support


### PR DESCRIPTION
Client option documented, useful to prevent and/or diagnose surprise breakages when using client as local variable.

Updated in gh-pages API templates in 125b4b0601da72bdffbb528acbf17321687e2fdf single page compiled in 53f8b9bb9cfd01733cb828196d9851d478b9a4a1 and whole site recompiled at 63f96fb774eed6d6c701a712bb750c1cde8b49c8

References (closed) ticket #914
