### PR TITLE
Fix support for ie8

### DIFF
--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -145,7 +145,7 @@ exports.attrs = function attrs(obj, escaped){
             ? buf.push(key)
             : buf.push(key + '="' + key + '"');
         }
-      } else if (0 == key.indexOf('data') && 'string' != typeof val) {
+      } else if (/^data/.test(key) && 'string' != typeof val) {
         buf.push(key + "='" + JSON.stringify(val) + "'");
       } else if ('class' == key) {
         if (escaped && escaped[key]){


### PR DESCRIPTION
Related to #1321

Add `map` and `filter` helpers and avoid using `indexOf`.

I based my changes on last stable version (0.35.0) but it looks like the dev branch master is way ahead of 0.35.0: where is the stable branch? I did not commit the build, should I? 
