### PR TITLE
Readme_zh_CN.md: complete strings forgotten to translate

### DIFF
--- a/Readme_zh-cn.md
+++ b/Readme_zh-cn.md
@@ -613,13 +613,13 @@ html
 !!! 5
 ```
 
-or
+或
 
 ```jade
 !!! html
 ```
 
-or
+或
 
 ```jade
 doctype html


### PR DESCRIPTION
`or` should be translated.
