### PR TITLE
Escape all elements inside pre tags

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -410,6 +410,8 @@ Compiler.prototype = {
       else self.buffer(name);
     }
 
+    if ('pre' == tag.name) this.escape = true;
+
     if (!this.hasCompiledTag) {
       if (!this.hasCompiledDoctype && 'html' == name) {
         this.visitDoctype();
@@ -438,7 +440,6 @@ Compiler.prototype = {
       this.visitAttributes(tag.attrs, tag.attributeBlocks);
       this.buffer('>');
       if (tag.code) this.visitCode(tag.code);
-      this.escape = 'pre' == tag.name;
       this.visit(tag.block);
 
       // pretty print
@@ -449,6 +450,9 @@ Compiler.prototype = {
       bufferName();
       this.buffer('>');
     }
+
+    if ('pre' == tag.name) this.escape = false;
+
     this.indents--;
   },
 

--- a/test/cases/pre.html
+++ b/test/cases/pre.html
@@ -1,0 +1,7 @@
+<pre>foo
+bar
+baz
+</pre>
+<pre><code>foo
+bar
+baz</code></pre>

--- a/test/cases/pre.jade
+++ b/test/cases/pre.jade
@@ -1,0 +1,10 @@
+pre.
+  foo
+  bar
+  baz
+
+pre
+  code.
+    foo
+    bar
+    baz


### PR DESCRIPTION
This allows the use of a code tag inside a pre tag without introducing errant whitespace.

Why? I have some Jade markup that looks something like this:

``` jade
pre
  code.
    foo
    bar
    baz
```

Because I've used a `code` tag instead of just using a `pre` tag, the resulting HTML has indentation which is then reflected on screen. If I use a `pre` tag on its own, the HTML has no indentation.

I'm using `code` inside `pre` because I'm using [Prism](https://github.com/LeaVerou/prism), which requires the use of the `code` tag, based on the [W3C's recommended way of marking up code snippets](http://www.w3.org/TR/html5/grouping-content.html#the-pre-element).

I've included a test case. Please let me know if you need anything else, or if you'd like me to make any changes.
