### PR TITLE
Remove automatic tag wrapping for filters

### DIFF
--- a/lib/filters.js
+++ b/lib/filters.js
@@ -8,13 +8,6 @@ function filter(name, str, options) {
     var res = filter[name](str, options);
   } else if (transformers[name]) {
     var res = transformers[name].renderSync(str, options);
-    if (transformers[name].outputFormat === 'js') {
-      res = '<script type="text/javascript">\n' + res + '</script>';
-    } else if (transformers[name].outputFormat === 'css') {
-      res = '<style type="text/css">' + res + '</style>';
-    } else if (transformers[name].outputFormat === 'xml') {
-      res = res.replace(/'/g, '&#39;');
-    }
   } else {
     throw new Error('unknown filter ":' + name + '"');
   }

--- a/test/cases/filters.coffeescript.jade
+++ b/test/cases/filters.coffeescript.jade
@@ -1,2 +1,3 @@
-:coffeescript
-  regexp = /\n/
+script(type='text/javascript')
+  :coffeescript
+    regexp = /\n/

--- a/test/cases/filters.less.jade
+++ b/test/cases/filters.less.jade
@@ -1,7 +1,8 @@
 html
   head
-    :less
-      @pad: 15px;
-      body {
-        padding: @pad;
-      }
+    style(type="text/css")
+      :less
+        @pad: 15px;
+        body {
+          padding: @pad;
+        }

--- a/test/cases/filters.stylus.jade
+++ b/test/cases/filters.stylus.jade
@@ -1,6 +1,7 @@
 html
   head
-    :stylus
-      body
-        padding: 50px
+    style(type="text/css")
+      :stylus
+        body
+          padding: 50px
   body

--- a/test/cases/include-filter-stylus.jade
+++ b/test/cases/include-filter-stylus.jade
@@ -1,1 +1,2 @@
-include:styl some.styl
+style(type="text/css")
+  include:styl some.styl

--- a/test/cases/includes.html
+++ b/test/cases/includes.html
@@ -1,12 +1,13 @@
 <p>bar</p>
 <body><p>:)</p><script>
   console.log("foo\nbar")
-</script><script type="text/javascript">
-var STRING_SUBSTITUTIONS = {    // table of character substitutions
+</script>
+  <script type="text/javascript">var STRING_SUBSTITUTIONS = {    // table of character substitutions
   '\t': '\\t',
   '\r': '\\r',
   '\n': '\\n',
   '"' : '\\"',
   '\\': '\\\\'
-};</script>
+};
+  </script>
 </body>

--- a/test/cases/includes.jade
+++ b/test/cases/includes.jade
@@ -6,4 +6,5 @@ include auxiliary/mixins
 body
   include auxiliary/smile.html
   include auxiliary/escapes.html
-  include:js auxiliary/includable.js
+  script(type="text/javascript")
+    include:js auxiliary/includable.js


### PR DESCRIPTION
Now that script tags can contain jade we should make more use of this feature.
