### PR TITLE
Ensure a newline after locals declaration in compiled client functions.

### DIFF
--- a/lib/jade.js
+++ b/lib/jade.js
@@ -112,7 +112,7 @@ function parse(str, options){
       + 'var jade_mixins = {};\n'
       + (options.self
         ? 'var self = locals || {};\n' + js
-        : addWith('locals || {}', js, globals)) + ';'
+        : addWith('locals || {}', '\n' + js, globals)) + ';'
       + 'return buf.join("");';
   } catch (err) {
     parser = parser.context();


### PR DESCRIPTION
For the case where debug information follows, I was receiving:

```
function template(locals) {
var jade_debug = [{ lineno: 1, filename: "../simple-jadeify/test/stuff/template.jade" }];
try {
var buf = [];
var jade_mixins = {};
var locals_ = (locals || {}),pageTitle = locals_.pageTitle,undefined = locals_.undefined,youAreUsingJade = locals_.youAreUsingJade;jade_debug.unshift({ lineno: 0, filename: "../simple-jadeify/test/stuff/template.jade" });
...
}
```

, with the lack of newline between `var locals` and `jade_debug.unshift(...)` making programmatically parsing the debug information difficult, aside from aesthetically being out of place with all the nicely newline-separated debug info.

PS: I seem to be consistently getting `lineno: 0` with debug output, which makes sourcemap generation difficult, since libraries like Mozilla [source-map](https://github.com/mozilla/source-map) [don't validate with lineno 0](https://github.com/mozilla/source-map/blob/master/lib/source-map/source-map-generator.js#L245). Is this intentional?

Thanks :)
