### PR TITLE
Allow self closing tags to contain white space

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -430,7 +430,9 @@ Compiler.prototype = {
       this.terse
         ? this.buffer('>')
         : this.buffer('/>');
-      if (tag.block && !(tag.block.type === 'Block' && tag.block.nodes.length === 0)) {
+      // if it is non-empty throw an error
+      if (tag.block && !(tag.block.type === 'Block' && tag.block.nodes.length === 0)
+      &&  tag.block.nodes.some(function (tag) { return tag.type !== 'Text' || !/^\s*$/.test(tag.val)})) {
         throw new Error(name + ' is self closing and should not have content.');
       }
     } else {

--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -780,6 +780,10 @@ Lexer.prototype = {
   },
 
   fail: function () {
+    if (/^ ($|\n)/.test(this.input)) {
+      this.consume(1);
+      return this.next();
+    }
     throw new Error('unexpected text ' + this.input.substr(0, 5));
   },
 

--- a/test/cases/tags.self-closing.html
+++ b/test/cases/tags.self-closing.html
@@ -4,5 +4,5 @@
   <foo/>
   <foo bar="baz"/>
   <foo>/</foo>
-  <foo bar="baz">/</foo>
+  <foo bar="baz">/</foo><img/><img/>
 </body>

--- a/test/cases/tags.self-closing.jade
+++ b/test/cases/tags.self-closing.jade
@@ -6,3 +6,7 @@ body
   foo(bar='baz')/
   foo /
   foo(bar='baz') /
+  //- can have a single space after them
+  img 
+  //- can have lots of white space after them
+  img    


### PR DESCRIPTION
I think it best if tags that contain pure whitespace are allowed even if they are self closing.  It's confusing to get an error that results from just a bit of trailing white space so wherever possible we should avoid that.
