### PR TITLE
add 'prefix' option to jade cli for client-side templates

### DIFF
--- a/bin/jade.js
+++ b/bin/jade.js
@@ -29,6 +29,7 @@ program
   .option('-o, --out <dir>', 'output the compiled html to <dir>')
   .option('-p, --path <path>', 'filename used to resolve includes')
   .option('-P, --pretty', 'compile pretty html output')
+  .option('--prefix <name>', 'custom name for client-side template function')
   .option('-c, --client', 'compile function for client-side runtime.js')
   .option('-D, --no-debug', 'compile without debugging (smaller functions)')
   .option('-w, --watch', 'watch files for changes and automatically re-render')
@@ -80,6 +81,10 @@ options.client = program.client;
 // --pretty
 
 options.pretty = program.pretty;
+
+// --prefix
+
+options.prefix = program.prefix;
 
 // --watch
 

--- a/lib/jade.js
+++ b/lib/jade.js
@@ -208,6 +208,10 @@ exports.compileClient = function(str, options){
     fn = parse(str, options);
   }
 
+  if (options.prefix) {
+    return 'var ' + options.prefix + ' = function(locals) {\n' + fn + '\n}';
+  }
+
   return 'function template(locals) {\n' + fn + '\n}';
 };
 


### PR DESCRIPTION
Addresses #1097. initial commit just covers the quick-and-dirty easy handling of @shabunc's original suggestion. 

Additional questions/follow-on commits:
1. What's the best way to write tests for this?
2. @ForbesLindesay suggests adding a default prefix that works as a CommonJS module
