### PR TITLE
Fix ignoration of "path"-option

### DIFF
--- a/bin/jade.js
+++ b/bin/jade.js
@@ -90,7 +90,7 @@ options.watch = program.watch;
 var files = program.args;
 
 // Add path from "path"-Option to files
-files[files.length] = program.path;
+files.push(program.path);
 
 // compile files
 


### PR DESCRIPTION
The "path"-option was only defined, but was not included in the actual "files" variable
