### PR TITLE
Pass through escaping of values like `null`

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -628,7 +628,9 @@ Compiler.prototype = {
         } else {
           var val = toConstant(attr.val);
           if (escaped && !(key.indexOf('data') === 0 && typeof val !== 'string')) {
-            val = runtime.escape(val);
+            var temp = runtime.escape(val);
+            if (temp !== '' + val)
+              val = temp;
           }
           buf.push(JSON.stringify(key) + ': ' + JSON.stringify(val));
         }

--- a/test/cases/attrs.js.html
+++ b/test/cases/attrs.js.html
@@ -2,3 +2,4 @@
 <meta key="answer" value="42"/><a class="class1 class2"></a><a class="tag-class class1 class2"></a><a href="/user/5" class="button"></a><a href="/user/5" class="button"></a>
 <meta key="answer" value="42"/><a class="class1 class2"></a><a class="tag-class class1 class2"></a>
 <div id="5" foo="bar"></div>
+<div bar="3" baz="baz"></div>

--- a/test/cases/attrs.js.jade
+++ b/test/cases/attrs.js.jade
@@ -13,3 +13,4 @@ a(class = ['class1', 'class2'])
 a.tag-class(class = ['class1', 'class2'])
 
 div(id=id)&attributes({foo: 'bar'})
+div(foo=null bar=1 + 2)&attributes({baz: 'baz'})


### PR DESCRIPTION
This fixes cases like `div(foo=null bar=1 + 2)&attributes({baz: 'baz'})` which you would expect to compile to `<div bar="3" baz="baz"></div>` but which actually has a spurious `foo="null"` attribute.
