### PR TITLE
fix line number for warning "missing space before text for line" issue 1...

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -626,6 +626,9 @@ Lexer.prototype = {
           }
         }
       }
+
+      this.lineno += str.split("\n").length - 1;
+
       for (var i = 0; i <= str.length; i++) {
         if (isEndOfAttribute(i)) {
           val = val.trim();


### PR DESCRIPTION
issue https://github.com/visionmedia/jade/issues/1368

fix wrong line number in case of newlines in jade tag attributes
