### PR TITLE
Prefer variables over properties of `jade` global

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -46,7 +46,7 @@ Compiler.prototype = {
 
   compile: function(){
     this.buf = [];
-    if (this.pp) this.buf.push("jade.indent = [];");
+    if (this.pp) this.buf.push("var jade_indent = [];");
     this.lastBufferedIdx = -1;
     this.visit(this.node);
     return this.buf.join('\n');
@@ -90,7 +90,7 @@ Compiler.prototype = {
           try {
             var rest = match[3];
             var range = parseJSExpression(rest);
-            var code = ('!' == match[2] ? '' : 'jade.escape') + "((jade.interp = " + range.src + ") == null ? '' : jade.interp)";
+            var code = ('!' == match[2] ? '' : 'jade.escape') + "((jade_interp = " + range.src + ") == null ? '' : jade_interp)";
           } catch (ex) {
             throw ex;
             //didn't match, just as if escaped
@@ -162,7 +162,7 @@ Compiler.prototype = {
     newline = newline ? '\n' : '';
     this.buffer(newline + Array(this.indents + offset).join('  '));
     if (this.parentIndents)
-      this.buf.push("buf.push.apply(buf, jade.indent);");
+      this.buf.push("buf.push.apply(buf, jade_indent);");
   },
 
   /**
@@ -286,9 +286,9 @@ Compiler.prototype = {
    */
 
   visitMixinBlock: function(block){
-    if (this.pp) this.buf.push("jade.indent.push('" + Array(this.indents + 1).join('  ') + "');");
+    if (this.pp) this.buf.push("jade_indent.push('" + Array(this.indents + 1).join('  ') + "');");
     this.buf.push('block && block();');
-    if (this.pp) this.buf.push("jade.indent.pop();");
+    if (this.pp) this.buf.push("jade_indent.pop();");
   },
 
   /**
@@ -328,7 +328,7 @@ Compiler.prototype = {
     name += (mixin.name[0]=='#' ? mixin.name.substr(2,mixin.name.length-3):'"'+mixin.name+'"')+']';
 
     if (mixin.call) {
-      if (pp) this.buf.push("jade.indent.push('" + Array(this.indents + 1).join('  ') + "');")
+      if (pp) this.buf.push("jade_indent.push('" + Array(this.indents + 1).join('  ') + "');")
       if (block || attrs.length || attrsBlocks.length) {
 
         this.buf.push(name + '.call({');
@@ -371,7 +371,7 @@ Compiler.prototype = {
       } else {
         this.buf.push(name + '(' + args + ');');
       }
-      if (pp) this.buf.push("jade.indent.pop();")
+      if (pp) this.buf.push("jade_indent.pop();")
     } else {
       this.buf.push(name + ' = function(' + args + '){');
       this.buf.push('var block = (this && this.block), attributes = (this && this.attributes) || {};');
@@ -522,7 +522,7 @@ Compiler.prototype = {
     // Buffer code
     if (code.buffer) {
       var val = code.val.trimLeft();
-      val = 'null == (jade.interp = '+val+') ? "" : jade.interp';
+      val = 'null == (jade_interp = '+val+') ? "" : jade_interp';
       if (code.escape) val = 'jade.escape(' + val + ')';
       this.bufferExpression(val);
     } else {
@@ -640,7 +640,7 @@ Compiler.prototype = {
           if (escaped && !(key.indexOf('data') === 0)) {
             val = 'jade.escape(' + val + ')';
           } else if (escaped) {
-            val = '(typeof (jade.interp = ' + val + ') == "string" ? jade.escape(jade.interp) : jade.interp)"';
+            val = '(typeof (jade_interp = ' + val + ') == "string" ? jade.escape(jade_interp) : jade_interp)"';
           }
           buf.push(JSON.stringify(key) + ': ' + val);
         }
@@ -658,9 +658,9 @@ Compiler.prototype = {
           return classEscaping[i] ? runtime.escape(cls) : cls;
         })));
       } else if (classes.length) {
-        classes = '(jade.interp = ' + JSON.stringify(classEscaping) + ',' +
+        classes = '(jade_interp = ' + JSON.stringify(classEscaping) + ',' +
           ' jade.joinClasses([' + classes.join(',') + '].map(jade.joinClasses).map(function (cls, i) {' +
-          '   return jade.interp[i] ? jade.escape(cls) : cls' +
+          '   return jade_interp[i] ? jade.escape(cls) : cls' +
           ' }))' +
           ')';
       }

--- a/lib/jade.js
+++ b/lib/jade.js
@@ -104,12 +104,14 @@ function parse(str, options){
 
     globals.push('jade');
     globals.push('jade_mixins');
+    globals.push('jade_interp');
     globals.push('jade_debug');
     globals.push('buf');
 
     return ''
       + 'var buf = [];\n'
       + 'var jade_mixins = {};\n'
+      + 'var jade_interp;\n'
       + (options.self
         ? 'var self = locals || {};\n' + js
         : addWith('locals || {}', '\n' + js, globals)) + ';'


### PR DESCRIPTION
Switch `jade.interp` with `jade_interp` and `jade.indent` with `jade_indent`.  In theory this ought to be faster.  It will also allow more templates to be capable of running without any runtime dependencies (which is nice).  It's also a lot cleaner in the presence of nested jade template calls.  
