### PR TITLE
Alter 'brackets' to 'parentheses' (attributes)

### DIFF
--- a/src/pages/tutorial.jade
+++ b/src/pages/tutorial.jade
@@ -81,7 +81,7 @@ block content
                  lines.</p>
       h4 Adding Attributes to your Tags
       p.
-        To add attributes you put them in brackets after the tag name, separated by an optional comma.
+        To add attributes you put them in parentheses after the tag name, separated by an optional comma.
       .row(data-control='interactive')
         .col-md-6
           +jade


### PR DESCRIPTION
Fixing a style issue, "parentheses" is used everywhere else in the document.
