### PR TITLE
More testing and a better warning for tags with multiple attributes

### DIFF
--- a/lib/nodes/text.js
+++ b/lib/nodes/text.js
@@ -10,8 +10,7 @@ var Node = require('./node');
  */
 
 var Text = module.exports = function Text(line) {
-  this.val = '';
-  if ('string' == typeof line) this.val = line;
+  this.val = line;
 };
 
 // Inherit from `Node`.

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -738,7 +738,7 @@ Parser.prototype = {
             continue;
           case 'attrs':
             if (seenAttrs) {
-              console.warn('You should not have jade tags with multiple attributes.');
+              console.warn(this.filename + ', line ' + this.peek().line + ':\nYou should not have jade tags with multiple attributes.');
             }
             seenAttrs = true;
             var tok = this.advance();

--- a/test/anti-cases/else-condition.jade
+++ b/test/anti-cases/else-condition.jade
@@ -1,0 +1,4 @@
+if foo
+  div
+else bar
+  article

--- a/test/anti-cases/tabs-and-spaces.jade
+++ b/test/anti-cases/tabs-and-spaces.jade
@@ -1,0 +1,3 @@
+div
+  div
+	article

--- a/test/error.reporting.js
+++ b/test/error.reporting.js
@@ -144,6 +144,29 @@ describe('error reporting', function () {
       assert(/test\.jade:1/.test(err.message))
       assert(/`doctype 5` is deprecated, you must now use `doctype html`/.test(err.message))
     });
+    it('warns about element-with-multiple-attributes', function () {
+      var consoleWarn = console.warn;
+      var log = '';
+      console.warn = function (str) {
+        log += str;
+      };
+      var res = jade.renderFile(__dirname + '/fixtures/element-with-multiple-attributes.jade');
+      console.warn = consoleWarn;
+      assert(/element-with-multiple-attributes.jade, line 1:/.test(log));
+      assert(/You should not have jade tags with multiple attributes/.test(log));
+      assert(res === '<div attr="val" foo="bar"></div>');
+    });
+    it('warns about missing space at the start of a line', function () {
+      var consoleWarn = console.warn;
+      var log = '';
+      console.warn = function (str) {
+        log += str;
+      };
+      var res = jade.render('%This line is plain text, but it should not be', {filename: 'foo.jade'});
+      console.warn = consoleWarn;
+      assert(log === 'Warning: missing space before text for line 1 of jade file "foo.jade"');
+      assert(res === '%This line is plain text, but it should not be');
+    });
   });
   describe('if you throw something that isn\'t an error', function () {
     it('just rethrows without modification', function () {

--- a/test/fixtures/element-with-multiple-attributes.jade
+++ b/test/fixtures/element-with-multiple-attributes.jade
@@ -1,0 +1,1 @@
+div(attr='val')(foo='bar')

--- a/test/jade.test.js
+++ b/test/jade.test.js
@@ -1,11 +1,8 @@
+'use strict';
 
-/**
- * Module dependencies.
- */
-
-var jade = require('../')
-  , assert = require('assert')
-  , fs = require('fs');
+var jade = require('../');
+var assert = require('assert');
+var fs = require('fs');
 
 var perfTest = fs.readFileSync(__dirname + '/fixtures/perf.jade', 'utf8')
 
@@ -975,6 +972,34 @@ describe('jade', function(){
       jade.renderFile(__dirname + '/fixtures/runtime.error.jade', function (err, actual) {
         assert.ok(err);
         done();
+      });
+    });
+  });
+
+  describe('.compileFileClient(path, options)', function () {
+    it('returns a string form of a function called `template`', function () {
+      var src = jade.compileFileClient(__dirname + '/cases/basic.jade');
+      var expected = fs.readFileSync(__dirname + '/cases/basic.html', 'utf8').replace(/\s/g, '');
+      var fn = Function('jade', src + '\nreturn template;')(jade.runtime);
+      var actual = fn({name: 'foo'}).replace(/\s/g, '');
+      assert(actual === expected);
+    });
+  });
+
+  describe('.runtime', function () {
+    describe('.merge', function () {
+      it('merges two attribute objects, giving precedensce to the second object', function () {
+        assert.deepEqual(jade.runtime.merge({}, {'class': ['foo', 'bar'], 'foo': 'bar'}), {'class': ['foo', 'bar'], 'foo': 'bar'});
+        assert.deepEqual(jade.runtime.merge({'class': ['foo'], 'foo': 'baz'}, {'class': ['bar'], 'foo': 'bar'}), {'class': ['foo', 'bar'], 'foo': 'bar'});
+        assert.deepEqual(jade.runtime.merge({'class': ['foo', 'bar'], 'foo': 'bar'}, {}), {'class': ['foo', 'bar'], 'foo': 'bar'});
+      });
+    });
+    describe('.attrs', function () {
+      it('Renders the given attributes object', function () {
+        assert.equal(jade.runtime.attrs({}), '');
+        assert.equal(jade.runtime.attrs({'class': []}), '');
+        assert.equal(jade.runtime.attrs({'class': ['foo']}), ' class="foo"');
+        assert.equal(jade.runtime.attrs({'class': ['foo'], 'id': 'bar'}), ' class="foo" id="bar"');
       });
     });
   });

--- a/test/run.js
+++ b/test/run.js
@@ -39,15 +39,25 @@ cases.forEach(function(test){
     var fn = jade.compile(str, { filename: path, pretty: true, basedir: 'test/cases' });
     var actual = fn({ title: 'Jade' });
 
-    fs.writeFileSync(__dirname + '/output/' + test + '.html', actual)
+    fs.writeFileSync(__dirname + '/output/' + test + '.html', actual);
     var clientCode = uglify.minify(jade.compileClient(str, {
+      filename: path,
+      pretty: true,
+      compileDebug: false,
+      basedir: 'test/cases'
+    }), {output: {beautify: true}, mangle: false, compress: false, fromString: true}).code;
+    var clientCodeDebug = uglify.minify(jade.compileClient(str, {
+      filename: path,
+      pretty: true,
+      compileDebug: true,
+      basedir: 'test/cases'
+    }), {output: {beautify: true}, mangle: false, compress: false, fromString: true}).code;
+    fs.writeFileSync(__dirname + '/output/' + test + '.js', uglify.minify(jade.compileClient(str, {
       filename: path,
       pretty: false,
       compileDebug: false,
-      client: true,
       basedir: 'test/cases'
-    }), {output: {beautify: true}, mangle: false, compress: false, fromString: true}).code;
-    fs.writeFileSync(__dirname + '/output/' + test + '.js', clientCode);
+    }), {output: {beautify: true}, mangle: false, compress: false, fromString: true}).code);
     if (/filter/.test(test)) {
       actual = actual.replace(/\n| /g, '');
       html = html.replace(/\n| /g, '');
@@ -56,6 +66,16 @@ cases.forEach(function(test){
       mixinsUnusedTestRan = true;
       assert(/never-called/.test(str), 'never-called is in the jade file for mixins-unused');
       assert(!/never-called/.test(clientCode), 'never-called should be removed from the code');
+    }
+    JSON.stringify(actual.trim()).should.equal(JSON.stringify(html));
+    actual = Function('jade', clientCode + '\nreturn template;')(jade.runtime)({ title: 'Jade' });
+    if (/filter/.test(test)) {
+      actual = actual.replace(/\n| /g, '');
+    }
+    JSON.stringify(actual.trim()).should.equal(JSON.stringify(html));
+    actual = Function('jade', clientCodeDebug + '\nreturn template;')(jade.runtime)({ title: 'Jade' });
+    if (/filter/.test(test)) {
+      actual = actual.replace(/\n| /g, '');
     }
     JSON.stringify(actual.trim()).should.equal(JSON.stringify(html));
   })


### PR DESCRIPTION
Adds filename and line number to the multiple attributes warning and increases code coverage.

Code Coverage Before:

```
Statements   : 97.39% ( 1380/1417 )
Branches     : 95% ( 741/780 )
Functions    : 95.81% ( 160/167 )
Lines        : 97.55% ( 1315/1348 )
```

Code Coverage After:

```
Statements   : 98.23% ( 1390/1415 )
Branches     : 96.53% ( 751/778 )
Functions    : 96.41% ( 161/167 )
Lines        : 98.44% ( 1326/1347 )
```
