### PR TITLE
Update with, making options.globals redundant

### DIFF
--- a/lib/jade.js
+++ b/lib/jade.js
@@ -100,7 +100,7 @@ function parse(str, options){
       console.error('\nCompiled Function:\n\n\u001b[90m%s\u001b[0m', js.replace(/^/gm, '  '));
     }
 
-    var globals = options.globals && Array.isArray(options.globals) ? options.globals : [];
+    var globals = [];
 
     globals.push('jade');
     globals.push('jade_mixins');

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "transformers": "2.1.0",
     "character-parser": "1.2.0",
     "monocle": "1.1.51",
-    "with": "~2.0.0",
+    "with": "~3.0.0",
     "constantinople": "~2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Everything will just implicitly fall back to globals if it's not defined
locally.
