### PR TITLE
Typo in readme fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Jade is a clean, whitespace sensitive syntax for writing html.  Here is a simple
 doctype html
 html(lang="en")
   head
-    title= pageTitle
+    title pageTitle
     script(type='text/javascript').
       if (foo) bar(1 + 5)
   body


### PR DESCRIPTION
Correct me, but jade outputs an empty title with the = appended to title.
