### PR TITLE
fixing issue #1454

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -451,7 +451,7 @@ Lexer.prototype = {
       if (captures = /^ *\(/.exec(this.input)) {
         try {
           var range = this.bracketExpression(captures[0].length - 1);
-          if (!/^ *[-\w]+ *=/.test(range.src)) { // not attributes
+          if (!/^\s*[-\w]+ *=/.test(range.src)) { // not attributes
             this.consume(range.end + 1);
             tok.args = range.src;
           }


### PR DESCRIPTION
fixing regex for detecting mixin attributes (vs. arguments) in mixin calls. This now allows any whitespace, not just space characters. Fixing issue #1454 which generates invalid JavaScript code otherwise.
