### PR TITLE
Update doctype.jade to reflect deprecations

### DIFF
--- a/src/pages/reference/doctype.jade
+++ b/src/pages/reference/doctype.jade
@@ -1,6 +1,6 @@
 h3#doctype doctype
 
-p To add a doctype use <code>doctype</code> (or <code>!!!</code> for short) followed by an optional value (which defaults to <code>html</code>)
+p To add a doctype use <code>doctype</code> followed by an optional value (which defaults to <code>html</code>). The shorthand <code>!!!</code> has been deprecated. 
 
 .row(data-control='interactive')
   .col-md-6


### PR DESCRIPTION
Was surprised to find that the '!!!' shorthand for 'doctype' was deprecated, figured the online documentation should acknowledge that.
