### PR TITLE
Use `<!doctype html>` instead of `<!DOCTYPE html>`

### DIFF
--- a/lib/doctypes.js
+++ b/lib/doctypes.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = {
-    'default': '<!DOCTYPE html>'
+    'default': '<!doctype html>'
   , 'xml': '<?xml version="1.0" encoding="utf-8" ?>'
   , 'transitional': '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">'
   , 'strict': '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">'


### PR DESCRIPTION
Return back to the lowercase doctype in order to be more consistent
with the lowercase of the html tags.

References:
- h5bp/html5-boilerplate#1522
- http://www.whatwg.org/specs/web-apps/current-work/multipage/syntax.html#the-doctype
