### PR TITLE
Added ' friends' to case fall through to match output

### DIFF
--- a/src/pages/reference/case.jade
+++ b/src/pages/reference/case.jade
@@ -31,7 +31,7 @@ p You can use fall through just like in a select statement in JavaScript
         case friends
           when 0
           when 1
-            p you have very few
+            p you have very few friends
           default
             p you have \#{friends} friends
   .col-md-6


### PR DESCRIPTION
Just started digging into jade and case fall through confused me with the missing ' friends' typo.  Thought I'd quickly fix it.
