### PR TITLE
Use <!doctype html> instead of <!DOCTYPE html>

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ becomes
 
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <title>Jade</title>

--- a/jade.js
+++ b/jade.js
@@ -707,7 +707,7 @@ Compiler.prototype = {
 'use strict';
 
 module.exports = {
-    'default': '<!DOCTYPE html>'
+    'default': '<!doctype html>'
   , 'xml': '<?xml version="1.0" encoding="utf-8" ?>'
   , 'transitional': '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">'
   , 'strict': '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">'
@@ -2293,7 +2293,7 @@ Comment.prototype.type = 'Comment';
 var Node = _dereq_('./node');
 
 /**
- * Initialize a `Doctype` with the given `val`. 
+ * Initialize a `Doctype` with the given `val`.
  *
  * @param {String} val
  * @api public

--- a/lib/doctypes.js
+++ b/lib/doctypes.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = {
-    'default': '<!DOCTYPE html>'
+    'default': '<!doctype html>'
   , 'xml': '<?xml version="1.0" encoding="utf-8" ?>'
   , 'transitional': '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">'
   , 'strict': '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">'

--- a/test/jade.test.js
+++ b/test/jade.test.js
@@ -21,13 +21,13 @@ describe('jade', function(){
   describe('.compile()', function(){
     it('should support doctypes', function(){
       assert.equal('<?xml version="1.0" encoding="utf-8" ?>', jade.render('doctype xml'));
-      assert.equal('<!DOCTYPE html>', jade.render('doctype html'));
+      assert.equal('<!doctype html>', jade.render('doctype html'));
       assert.equal('<!DOCTYPE foo bar baz>', jade.render('doctype foo bar baz'));
-      assert.equal('<!DOCTYPE html>', jade.render('doctype html'));
-      assert.equal('<!DOCTYPE html>', jade.render('doctype', { doctype:'html' }));
-      assert.equal('<!DOCTYPE html>', jade.render('doctype html', { doctype:'xml' }));
+      assert.equal('<!doctype html>', jade.render('doctype html'));
+      assert.equal('<!doctype html>', jade.render('doctype', { doctype:'html' }));
+      assert.equal('<!doctype html>', jade.render('doctype html', { doctype:'xml' }));
       assert.equal('<html></html>', jade.render('html'));
-      assert.equal('<!DOCTYPE html><html></html>', jade.render('html', { doctype:'html' }));
+      assert.equal('<!doctype html><html></html>', jade.render('html', { doctype:'html' }));
       assert.equal('<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML Basic 1.1//EN>', jade.render('doctype html PUBLIC "-//W3C//DTD XHTML Basic 1.1//EN'));
     });
 
@@ -330,9 +330,9 @@ describe('jade', function(){
     });
 
     it('should support test html 5 mode', function(){
-      assert.equal('<!DOCTYPE html><input type="checkbox" checked>', jade.render('doctype html\ninput(type="checkbox", checked)'));
-      assert.equal('<!DOCTYPE html><input type="checkbox" checked>', jade.render('doctype html\ninput(type="checkbox", checked=true)'));
-      assert.equal('<!DOCTYPE html><input type="checkbox">', jade.render('doctype html\ninput(type="checkbox", checked= false)'));
+      assert.equal('<!doctype html><input type="checkbox" checked>', jade.render('doctype html\ninput(type="checkbox", checked)'));
+      assert.equal('<!doctype html><input type="checkbox" checked>', jade.render('doctype html\ninput(type="checkbox", checked=true)'));
+      assert.equal('<!doctype html><input type="checkbox">', jade.render('doctype html\ninput(type="checkbox", checked= false)'));
     });
 
     it('should support multi-line attrs', function(){


### PR DESCRIPTION
Return back to the lowercase doctype in order to be more consistent with the lowercase of the html tags.

References:
- h5bp/html5-boilerplate#1522
- http://www.whatwg.org/specs/web-apps/current-work/multipage/syntax.html#the-doctype
