### PR TITLE
escaping for dots in tag names added

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -215,9 +215,10 @@ Lexer.prototype = {
 
   tag: function() {
     var captures;
-    if (captures = /^(\w[-:\w]*)(\/?)/.exec(this.input)) {
+    if (captures = /^(\w(?:[-:\w]|(?:\\\.))*)(\/?)/.exec(this.input)) {
       this.consume(captures[0].length);
       var tok, name = captures[1];
+      name = name.replace(/\\\./g, '.');
       if (':' == name[name.length - 1]) {
         name = name.slice(0, -1);
         tok = this.tok('tag', name);

--- a/test/jade.test.js
+++ b/test/jade.test.js
@@ -320,6 +320,12 @@ describe('jade', function(){
       assert.equal('<html><body><h1>Wahoo</h1><p>test</p></body></html>', jade.render('html\n  body\n   h1 Wahoo\n   p test'));
     });
 
+    it('should support escaped dots in tag name', function(){
+      assert.equal('<dotted.tag></dotted.tag>', jade.render('dotted\\.tag'));
+      assert.equal('<dotted.tag.name></dotted.tag.name>', jade.render('dotted\\.tag\\.name'));
+      assert.equal('<dotted.tag.name/>', jade.render('dotted\\.tag\\.name/'));
+    });
+
     it('should support interpolation values', function(){
       assert.equal('<p>Users: 15</p>', jade.render('p Users: #{15}'));
       assert.equal('<p>Users: </p>', jade.render('p Users: #{null}'));


### PR DESCRIPTION
I use jade to create template files for other html based template engines. Some of them use dots in their tag names. So I added support of dots in tag names.
