### PR TITLE
removeAttribute() does not remove from attributeNames

### DIFF
--- a/lib/nodes/attrs.js
+++ b/lib/nodes/attrs.js
@@ -54,6 +54,7 @@ Attrs.prototype.removeAttribute = function(name){
 
   for (var i = 0, len = this.attrs.length; i < len; ++i) {
     if (this.attrs[i] && this.attrs[i].name == name) {
+      delete this.attributeNames[i];
       delete this.attrs[i];
     }
   }


### PR DESCRIPTION
To change an attribute already defined I do:
-> removeAttribute('attrName') -> setAttribute('attrName', 'newVal').
The removeAttribute method is missing to remove the name also from attributeNames.
Cheers
