### PR TITLE
Track dependencies

### DIFF
--- a/lib/jade.js
+++ b/lib/jade.js
@@ -82,7 +82,7 @@ exports.cache = {};
  *
  * @param {String} str
  * @param {Object} options
- * @return {String}
+ * @return {Object}
  * @api private
  */
 
@@ -122,7 +122,7 @@ function parse(str, options){
   globals.push('jade_debug');
   globals.push('buf');
 
-  return ''
+  var body = ''
     + 'var buf = [];\n'
     + 'var jade_mixins = {};\n'
     + 'var jade_interp;\n'
@@ -130,6 +130,7 @@ function parse(str, options){
       ? 'var self = locals || {};\n' + js
       : addWith('locals || {}', '\n' + js, globals)) + ';'
     + 'return buf.join("");';
+  return {body: body, dependencies: parser.dependencies};
 }
 
 /**
@@ -157,17 +158,18 @@ exports.compile = function(str, options){
 
   str = String(str);
 
+  var parsed = parse(str, options);
   if (options.compileDebug !== false) {
     fn = [
         'var jade_debug = [{ lineno: 1, filename: ' + filename + ' }];'
       , 'try {'
-      , parse(str, options)
+      , parsed.body
       , '} catch (err) {'
       , '  jade.rethrow(err, jade_debug[0].filename, jade_debug[0].lineno' + (options.compileDebug === true ? ',' + JSON.stringify(str) : '') + ');'
       , '}'
     ].join('\n');
   } else {
-    fn = parse(str, options);
+    fn = parsed.body;
   }
   fn = new Function('locals, jade', fn)
   var res = function(locals){ return fn(locals, Object.create(runtime)) };
@@ -178,6 +180,7 @@ exports.compile = function(str, options){
       return exports.compileClient(str, options);
     };
   }
+  res.dependencies = parsed.dependencies;
   return res;
 };
 
@@ -210,14 +213,14 @@ exports.compileClient = function(str, options){
     fn = [
         'var jade_debug = [{ lineno: 1, filename: ' + filename + ' }];'
       , 'try {'
-      , parse(str, options)
+      , parse(str, options).body
       , '} catch (err) {'
       , '  jade.rethrow(err, jade_debug[0].filename, jade_debug[0].lineno, ' + JSON.stringify(str) + ');'
       , '}'
     ].join('\n');
   } else {
     options.compileDebug = false;
-    fn = parse(str, options);
+    fn = parse(str, options).body;
   }
 
   return 'function template(locals) {\n' + fn + '\n}';

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -28,6 +28,7 @@ var Parser = exports = module.exports = function Parser(str, filename, options){
   this.options = options;
   this.contexts = [this];
   this.inMixin = false;
+  this.dependencies = [];
 };
 
 /**
@@ -481,8 +482,10 @@ Parser.prototype = {
     var path = this.resolvePath(this.expect('extends').val.trim(), 'extends');
     if ('.jade' != path.substr(-5)) path += '.jade';
 
+    this.dependencies.push(path);
     var str = fs.readFileSync(path, 'utf8');
     var parser = new this.constructor(str, path, this.options);
+    parser.dependencies = this.dependencies;
 
     parser.blocks = this.blocks;
     parser.contexts = this.contexts;
@@ -549,7 +552,7 @@ Parser.prototype = {
     var tok = this.expect('include');
 
     var path = this.resolvePath(tok.val.trim(), 'include');
-
+    this.dependencies.push(path);
     // has-filter
     if (tok.filter) {
       var str = fs.readFileSync(path, 'utf8').replace(/\r/g, '');
@@ -571,6 +574,8 @@ Parser.prototype = {
 
     var str = fs.readFileSync(path, 'utf8');
     var parser = new this.constructor(str, path, this.options);
+    parser.dependencies = this.dependencies;
+
     parser.blocks = utils.merge({}, this.blocks);
     parser.included = true;
 

--- a/test/dependencies/dependency1.jade
+++ b/test/dependencies/dependency1.jade
@@ -1,0 +1,1 @@
+strong dependency1

--- a/test/dependencies/dependency2.jade
+++ b/test/dependencies/dependency2.jade
@@ -1,0 +1,1 @@
+include dependency3

--- a/test/dependencies/dependency3.jade
+++ b/test/dependencies/dependency3.jade
@@ -1,0 +1,1 @@
+strong dependency3

--- a/test/dependencies/extends1.jade
+++ b/test/dependencies/extends1.jade
@@ -1,0 +1,1 @@
+extends dependency1

--- a/test/dependencies/extends2.jade
+++ b/test/dependencies/extends2.jade
@@ -1,0 +1,1 @@
+extends dependency2

--- a/test/dependencies/include1.jade
+++ b/test/dependencies/include1.jade
@@ -1,0 +1,1 @@
+include dependency1

--- a/test/dependencies/include2.jade
+++ b/test/dependencies/include2.jade
@@ -1,0 +1,1 @@
+include dependency2

--- a/test/jade.test.js
+++ b/test/jade.test.js
@@ -1,8 +1,9 @@
 'use strict';
 
-var jade = require('../');
 var assert = require('assert');
 var fs = require('fs');
+var path = require('path');
+var jade = require('../');
 
 var perfTest = fs.readFileSync(__dirname + '/fixtures/perf.jade', 'utf8')
 
@@ -1004,6 +1005,43 @@ describe('jade', function(){
       ].join('\n');
 
       assert.equal(jade.render(indents), '0,1,2,3,0,4,4,3,3,4,2,0,2,0,1');
+    });
+  });
+
+  describe('.compile().dependencies', function() {
+    it('should list the filename of the template referenced by extends', function(){
+      var filename = __dirname + '/dependencies/extends1.jade';
+      var str = fs.readFileSync(filename, 'utf8');
+      var info = jade.compile(str, {filename: filename});
+      assert.deepEqual([
+        path.resolve(__dirname + '/dependencies/dependency1.jade')
+      ], info.dependencies);
+    });
+    it('should list the filename of the template referenced by an include', function() {
+      var filename = __dirname + '/dependencies/include1.jade';
+      var str = fs.readFileSync(filename, 'utf8');
+      var info = jade.compile(str, {filename: filename});
+      assert.deepEqual([
+        path.resolve(__dirname + '/dependencies/dependency1.jade')
+      ], info.dependencies);
+    });
+    it('should list the dependencies of extends dependencies', function() {
+      var filename = __dirname + '/dependencies/extends2.jade';
+      var str = fs.readFileSync(filename, 'utf8');
+      var info = jade.compile(str, {filename: filename});
+      assert.deepEqual([
+        path.resolve(__dirname + '/dependencies/dependency2.jade'),
+        path.resolve(__dirname + '/dependencies/dependency3.jade')
+      ], info.dependencies);
+    });
+    it('should list the dependencies of include dependencies', function() {
+      var filename = __dirname + '/dependencies/include2.jade';
+      var str = fs.readFileSync(filename, 'utf8');
+      var info = jade.compile(str, {filename: filename});
+      assert.deepEqual([
+        path.resolve(__dirname + '/dependencies/dependency2.jade'),
+        path.resolve(__dirname + '/dependencies/dependency3.jade')
+      ],info.dependencies);
     });
   });
 });


### PR DESCRIPTION
Thanks to @sdether for the initial work on this in #1252.  The API has been changed a bit and the output has been simplified a lot so it just returns an array of strings rather than a structured object.  As an additional bonus, the tests pass on windows.

[closes #1252]
