### PR TITLE
Also resolve path of src/href attributes.

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -488,7 +488,7 @@ Parser.prototype = {
       val = val.substr(1, -1);
     }
 
-    attr.val = this.resolvePath(val.substr(1, -1), 'src/href attributes');
+    attr.val = this.resolvePath(val, 'src/href attributes');
 
     if (attr.escaped) {
       // Add quotes again (dirty)


### PR DESCRIPTION
This PR makes referencing to local files (including images) work with the `basedir` option, just like the include/extend commands do.

This is based on two assumptions:
1. Escaped attributes, in this case "src" and "href", always start and end with double quotes  
   (I couldn't find a clean way to extract the URL, suggestions are welcome);
2. The `basedir` option is also used in front end,  
   which would make `img(src="/test/image.png")` compile to `<img src="/base/dir/test/image.png"/>`.

Please verify.
