### PR TITLE
Fix #1586 and add tests for more coverage

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -280,7 +280,9 @@ Lexer.prototype = {
    */
 
   text: function() {
-    return this.scan(/^(?:\| ?| )([^\n]+)/, 'text') || this.scan(/^(<[^\n]*)/, 'text');
+    return this.scan(/^(?:\| ?| )([^\n]+)/, 'text') ||
+      this.scan(/^\|?( )/, 'text') ||
+      this.scan(/^(<[^\n]*)/, 'text');
   },
 
   textFail: function () {
@@ -297,8 +299,11 @@ Lexer.prototype = {
    */
 
   dot: function() {
-    this.pipeless = true;
-    return this.scan(/^\./, 'dot');
+    var match;
+    if (match = this.scan(/^\./, 'dot')) {
+      this.pipeless = true;
+      return match;
+    }
   },
 
   /**
@@ -374,7 +379,7 @@ Lexer.prototype = {
    * Yield.
    */
 
-  yield: function() {
+  'yield': function() {
     return this.scan(/^yield */, 'yield');
   },
 
@@ -400,7 +405,7 @@ Lexer.prototype = {
         throw new Error('expected space after include:filter but got ' + JSON.stringify(this.input[0]));
       }
       captures = /^ *([^\n]+)/.exec(this.input);
-      if (!captures) {
+      if (!captures || captures[1].trim() === '') {
         throw new Error('missing path for include:filter');
       }
       this.consume(captures[0].length);
@@ -864,10 +869,6 @@ Lexer.prototype = {
   },
 
   fail: function () {
-    if (/^ ($|\n)/.test(this.input)) {
-      this.consume(1);
-      return this.next();
-    }
     throw new Error('unexpected text ' + this.input.substr(0, 5));
   },
 

--- a/test/error.reporting.js
+++ b/test/error.reporting.js
@@ -85,6 +85,20 @@ describe('error reporting', function () {
         assert(/foo\(/.test(err.message))
       });
     });
+    describe('Unexpected character', function () {
+      it('includes details of where the error was thrown', function () {
+        var err = getError('ul?', {});
+        assert(err.message.indexOf('unexpected text ?') !== -1);
+      });
+    });
+    describe('Include filtered', function () {
+      it('includes details of where the error was thrown', function () {
+        var err = getError('include:js()!', {});
+        assert(err.message.indexOf('expected space after include:filter but got "!"') !== -1);
+        var err = getError('include:js ', {});
+        assert(err.message.indexOf('missing path for include:filter') !== -1);
+      });
+    });
   });
   describe('runtime errors', function () {
     describe('with no filename and `compileDebug` left undefined', function () {

--- a/test/jade.test.js
+++ b/test/jade.test.js
@@ -918,7 +918,11 @@ describe('jade', function(){
 
     it('should be reasonably fast', function(){
       jade.compile(perfTest, {})
-    })
+    });
+    it('allows trailing space (see #1586)', function () {
+      var res = jade.render('ul \n  li An Item');
+      assert.equal('<ul> <li>An Item</li></ul>', res);
+    });
   });
 
   describe('.renderFile()', function () {


### PR DESCRIPTION
This fixes a regression in 1.4.0 where a tag followed by a single space was inadvertently seen as "pipeless-text" which resulted in an exception.

It also removes some code that was made redundant by this fix and adds tests for the error messages thrown by getting `include:filter` wrong.

I'm going to merge this straight away, since it fixes a bug in last night's release but let me know if anything needs fixing/tidying up.
