### PR TITLE
Fix block warnings when block is inside "code"

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -27,11 +27,11 @@ exports.walkAST = function walkAST(ast, before, after) {
     case 'Mixin':
     case 'Tag':
     case 'When':
+    case 'Code':
       ast.block && walkAST(ast.block, before, after);
       break;
     case 'Attrs':
     case 'BlockComment':
-    case 'Code':
     case 'Comment':
     case 'Doctype':
     case 'Filter':

--- a/test/cases/blocks-in-if.html
+++ b/test/cases/blocks-in-if.html
@@ -1,0 +1,1 @@
+<p>ajax contents</p>

--- a/test/cases/blocks-in-if.jade
+++ b/test/cases/blocks-in-if.jade
@@ -1,0 +1,19 @@
+//- see https://github.com/visionmedia/jade/issues/1589
+
+-var ajax = true
+
+-if( ajax )
+    //- return only contents if ajax requests
+    block contents
+        p ajax contents
+
+-else
+    //- return all html
+    doctype html
+    html
+        head
+            meta( charset='utf8' )
+            title sample
+            body
+                block contents
+                    p all contetns


### PR DESCRIPTION
[fixes #1589]

A layout like:

``` jade
if condition
  block myBlock
```

should not emit a warning, since `myBlock` may be used.
