### PR TITLE
End-of-file newline in pretty mode

### DIFF
--- a/lib/jade.js
+++ b/lib/jade.js
@@ -129,8 +129,7 @@ function parse(str, options){
     + (options.self
       ? 'var self = locals || {};\n' + js
       : addWith('locals || {}', '\n' + js, globals)) + ';'
-    + 'return buf.join("")'
-    + (options.pretty ? ' + "\\n"' : '') + ';'
+    + 'return buf.join("") + "\\n";';
   return {body: body, dependencies: parser.dependencies};
 }
 


### PR DESCRIPTION
- Good practice (always newline at EOL)
- Avoids shell prompt ending up to the right of
  last line when doing e.g. CURL
