### PR TITLE
Ignore "fs" module in browser builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "compile-runtime": "browserify ./lib/runtime.js --standalone jade > runtime.js"
   },
   "browser": {
+    "fs": false,
     "./lib/filters.js": "./lib/filters-client.js"
   }
 }


### PR DESCRIPTION
While browserify uses an empty module for fs by default, webpack does not and will refuse to bundle the jade runtime. (webpack/jade-loader#8)
