### PR TITLE
Treat Handlebars expressions as text

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -193,6 +193,20 @@ Lexer.prototype = {
   },
 
   /**
+   * Handlebars.
+   */
+
+  handlebars: function() {
+    var captures;
+    if (captures = /^\{\{([^\n]*)\}\}/.exec(this.input)) {
+      this.consume(captures[0].length);
+      var tok = this.tok('text', captures[0]);
+      this.pipeless = true;
+      return tok;
+    }
+  },
+
+  /**
    * Interpolated tag.
    */
 
@@ -925,6 +939,7 @@ Lexer.prototype = {
       || this.indent()
       || this.text()
       || this.comment()
+      || this.handlebars()
       || this.colon()
       || this.dot()
       || this.textFail()

--- a/test/cases/handlebars.html
+++ b/test/cases/handlebars.html
@@ -1,0 +1,2 @@
+{{#if foo}}
+<h1>Title</h1>{{/if}}

--- a/test/cases/handlebars.jade
+++ b/test/cases/handlebars.jade
@@ -1,0 +1,3 @@
+{{#if foo}}
+h1 Title
+{{/if}}


### PR DESCRIPTION
This is a bit of a strange one. We use Handlebars on top of Jade. Jade acts as the formatter and Handlebars as the logic processor in the browser. Recently the Jade compiler started emitting the warning "Warning: missing space before text for line x of jade file y" when hitting one of the Handlebar expressions. This patch treats Handlebar expressions as text. 
