### PR TITLE
Update all of the easy dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,14 +18,14 @@
     "jade": "./bin/jade.js"
   },
   "dependencies": {
-    "character-parser": "1.2.0",
-    "commander": "2.1.0",
-    "constantinople": "~2.0.0",
+    "character-parser": "1.2.1",
+    "commander": "2.3.0",
+    "constantinople": "~3.0.1",
     "mkdirp": "~0.5.0",
     "monocle": "1.1.51",
     "transformers": "2.1.0",
     "void-elements": "~1.0.0",
-    "with": "~3.0.0"
+    "with": "~4.0.0"
   },
   "devDependencies": {
     "coffee-script": "*",
@@ -38,11 +38,11 @@
     "uglify-js": "*",
     "browserify": "*",
     "linify": "*",
-    "less-file": "0.0.8",
-    "express": "~3.4.8",
-    "browserify-middleware": "~2.4.0",
+    "less-file": "0.0.9",
+    "express": "~4.9.5",
+    "browserify-middleware": "~4.1.0",
     "twbs": "0.0.6",
-    "highlight-codemirror": "~3.20.0",
+    "highlight-codemirror": "~4.1.0",
     "inconsolata": "0.0.2",
     "jade-code-mirror": "~1.0.5",
     "code-mirror": "~3.22.0",
@@ -51,7 +51,7 @@
     "marked": "~0.3.2",
     "stop": "^3.0.0-rc1",
     "opener": "^1.3.0",
-    "github-basic": "^3.0.0",
+    "github-basic": "^4.1.2",
     "pull-request": "^3.0.0",
     "lsr": "^1.0.0",
     "rimraf": "^2.2.8"


### PR DESCRIPTION
Low priority.  All tests still pass.  

"transformers" and "code-mirror" need some thought; updating "transformers" breaks the tests, and "code-mirror" has been deprecated in favor of "codemirror".
