### PR TITLE
provide omit optional HTML tags as a option

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -6,6 +6,7 @@ var doctypes = require('./doctypes');
 var runtime = require('./runtime');
 var utils = require('./utils');
 var selfClosing = require('void-elements');
+var optionalTags = require('optional-tags');
 var parseJSExpression = require('character-parser').parseMax;
 var constantinople = require('constantinople');
 
@@ -42,6 +43,7 @@ var Compiler = module.exports = function Compiler(node, options) {
   this.mixins = {};
   this.dynamicMixins = false;
   if (options.doctype) this.setDoctype(options.doctype);
+  if (options.omitTag) this.omittedTags = optionalTags(this.pp ? '' : options.omitTag);
 };
 
 /**
@@ -430,6 +432,7 @@ Compiler.prototype = {
     this.indents++;
     var name = tag.name
       , pp = this.pp
+      , omittedTags = this.omittedTags
       , self = this;
 
     function bufferName() {
@@ -478,9 +481,12 @@ Compiler.prototype = {
       if (pp && !tag.isInline() && 'pre' != tag.name && !tag.canInline())
         this.prettyIndent(0, true);
 
-      this.buffer('</');
-      bufferName();
-      this.buffer('>');
+      // provide omit tags as optional
+      if (!omittedTags || !~omittedTags.ends.indexOf(tag.name)) {
+        this.buffer('</');
+        bufferName();
+        this.buffer('>');
+      }
     }
 
     if ('pre' == tag.name) this.escape = false;

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "monocle": "1.1.51",
     "transformers": "2.1.0",
     "void-elements": "~1.0.0",
+    "optional-tags": "~0.0.4",
     "with": "~4.0.0"
   },
   "devDependencies": {

--- a/test/jade.test.js
+++ b/test/jade.test.js
@@ -872,6 +872,27 @@ describe('jade', function(){
     it('does not produce warnings for issue-1593', function () {
       jade.compileFile(__dirname + '/fixtures/issue-1593/index.jade');
     });
+
+    it('should omit optional end tags', function(){
+      var str = [
+        'ul',
+        '  li',
+        '    dl',
+        '      dt',
+        '      dd'
+      ].join('\n');
+
+      assert.equal('<ul><li><dl><dt><dd></dl></ul>', jade.render(str,{omitTag:true}));
+
+      var str2 = [
+        'body',
+        '  p say hi'
+      ].join('\n');
+
+      assert.equal('<body>  <p>say hi</p></body>', jade.render(str2,{omitTag:'radical', pretty: true}).split('\n').join(''));
+      assert.equal('<body><p>say hi</p>', jade.render(str2,{omitTag:'radical'}));
+      assert.equal('<body><p>say hi', jade.render(str2,{omitTag:'dangerous'}));
+    });
   });
 
   describe('.render()', function(){


### PR DESCRIPTION
It's a W3C's spec: http://www.w3.org/html/wg/drafts/html/master/syntax.html#optional-tags

In browser, before HTML minify and after it, the result is different, because browser must be [generated implied end tags](http://www.w3.org/TR/html5/syntax.html#generate-implied-end-tags).

For Example, **[in this w3's essay](http://www.w3.org/People/Bos/CSS-variables) by Bert Bos, W3C/ERCIM, bert@w3.org**, he used  vast numbers of omitted tags.

If you using default option: true or  'safe', it's just provide 12 absolutely safe tags, most browsers(IE6+/chrome/safari/Firefox/Opera/...) works perfect.
Actually, it appeared in HTML 4.01, and we used many years on our corp's projects.

In test case, other levels will be fallback to "safe" when using "pretty: true", because it's really unsafe with space character and comment by [w3's SPEC](http://www.w3.org/html/wg/drafts/html/master/syntax.html#optional-tags).

Other features:
- Optimize transfer: 
- Improve performance: 
- Make easier to handle [white-space processing model](http://www.w3.org/TR/2013/WD-css-text-3-20131010/#white-space-rules)
- Doesn't affect the performance of the browser

Could you think about it please? :smile: 
