### PR TITLE
Fix link to Travis CI and GitHub repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ becomes
 </html>
 ```
 
-The official [jade tutorial](http://jade-lang.com/tutorial/) is a great place to start.  While that (and the syntax documentation) is being finished, you can view some of the old documentation [here](https://github.com/visionmedia/jade/blob/master/jade.md) and [here](https://github.com/visionmedia/jade/blob/master/jade-language.md)
+The official [jade tutorial](http://jade-lang.com/tutorial/) is a great place to start.  While that (and the syntax documentation) is being finished, you can view some of the old documentation [here](https://github.com/jadejs/jade/blob/master/jade.md) and [here](https://github.com/jadejs/jade/blob/master/jade-language.md)
 
 ## API
 
@@ -92,7 +92,7 @@ var html = jade.renderFile('filename.jade', merge(options, locals));
 
 ## Browser Support
 
- The latest version of jade can be download for the browser in standalone form from [here](https://github.com/visionmedia/jade/raw/master/jade.js).  It only supports the very latest browsers though, and is a large file.  It is recommended that you pre-compile your jade templates to JavaScript and then just use the [runtime.js](https://github.com/visionmedia/jade/raw/master/runtime.js) library on the client.
+ The latest version of jade can be download for the browser in standalone form from [here](https://github.com/jadejs/jade/raw/master/jade.js).  It only supports the very latest browsers though, and is a large file.  It is recommended that you pre-compile your jade templates to JavaScript and then just use the [runtime.js](https://github.com/jadejs/jade/raw/master/runtime.js) library on the client.
 
  To compile a template for use on the client using the command line, do:
 
@@ -123,7 +123,7 @@ Tutorials:
   - cssdeck interactive [Jade syntax tutorial](http://cssdeck.com/labs/learning-the-jade-templating-engine-syntax)
   - cssdeck interactive [Jade logic tutorial](http://cssdeck.com/labs/jade-templating-tutorial-codecast-part-2)
   - [Jade について。](https://gist.github.com/japboy/5402844) (A Japanese Tutorial)
-  - [Jade - 模板引擎](https://github.com/visionmedia/jade/blob/master/Readme_zh-cn.md)
+  - [Jade - 模板引擎](https://github.com/jadejs/jade/blob/master/Readme_zh-cn.md)
 
 Implementations in other languages:
 

--- a/docs/views/layout.jade
+++ b/docs/views/layout.jade
@@ -36,8 +36,8 @@ html
                 li(class=section === 'history' ? 'active' : false)
                   a(href='/history') Change Log
                 li: a(href=path('/coverage/')) Code Coverage
-                li: a(href='https://travis-ci.org/visionmedia/jade') Test Results
-                li: a(href='https://github.com/visionmedia/jade') GitHub Repository
+                li: a(href='https://travis-ci.org/jadejs/jade') Test Results
+                li: a(href='https://github.com/jadejs/jade') GitHub Repository
               block navigation
         .container
           block content

--- a/test/cases/blocks-in-if.jade
+++ b/test/cases/blocks-in-if.jade
@@ -1,4 +1,4 @@
-//- see https://github.com/visionmedia/jade/issues/1589
+//- see https://github.com/jadejs/jade/issues/1589
 
 -var ajax = true
 

--- a/test/cases/mixin-via-include.jade
+++ b/test/cases/mixin-via-include.jade
@@ -1,4 +1,4 @@
-//- regression test for https://github.com/visionmedia/jade/issues/1435
+//- regression test for https://github.com/jadejs/jade/issues/1435
 
 include ../fixtures/mixin-include.jade
 


### PR DESCRIPTION
jade is now under the jadejs organization.
