### PR TITLE
doc: Add documentation for options.globals

### DIFF
--- a/docs/views/api.jade
+++ b/docs/views/api.jade
@@ -33,6 +33,9 @@ block content
       dt self:
       dd.type.boolean boolean
       dd.description Use a #[code self] namespace to hold the locals (false by default)
+      dt globals:
+      dd.type.array array
+      dd.description An array of objects in global namespace that will not be explicitly made available locally
       dt debug:
       dd.type.boolean boolean
       dd.description If set to true, the tokens and function body is logged to stdout


### PR DESCRIPTION
Partially addresses the concern in jadejs/jade#1689
