### PR TITLE
Pin to less <2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "markdown": "*",
     "stylus": "*",
     "should": "*",
-    "less": "*",
+    "less": "<2.0.0",
     "uglify-js": "*",
     "browserify": "*",
     "linify": "*",


### PR DESCRIPTION
transformer doesn't support less 2.0.0 yet.

Temporarily fixes the build.

See #1718.
