### PR TITLE
Warn about future change to ISO 8601 style dates

### DIFF
--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -123,10 +123,20 @@ exports.attr = function attr(key, val, escaped, terse) {
       console.warn('Since Jade 2.0.0, ampersands (`&`) in data attributes ' +
                    'will be escaped to `&amp;`');
     };
+    if (val && typeof val.toISOString === 'function') {
+      console.warn('Jade will eliminate the double quotes around dates in ' +
+                   'ISO form after 2.0.0');
+    }
     return ' ' + key + "='" + JSON.stringify(val).replace(/'/g, '&apos;') + "'";
   } else if (escaped) {
+    if (val && typeof val.toISOString === 'function') {
+      console.warn('Jade will stringify dates in ISO form after 2.0.0');
+    }
     return ' ' + key + '="' + exports.escape(val) + '"';
   } else {
+    if (val && typeof val.toISOString === 'function') {
+      console.warn('Jade will stringify dates in ISO form after 2.0.0');
+    }
     return ' ' + key + '="' + val + '"';
   }
 };


### PR DESCRIPTION
See #1062, #1677.

New approach that warns in both data\* cases and non-data\* cases, although differently.
