### PR TITLE
Warn about using `lexer` as a local in `jade.render()`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -293,6 +293,11 @@ exports.render = function(str, options, fn){
 
   options = options || {};
 
+  if (options.lexer) {
+    console.warn('Using `lexer` as a local in render() is deprecated and '
+               + 'will be interpreted as an option in Jade 2.0.0');
+  }
+
   // cache requires .filename
   if (options.cache && !options.filename) {
     throw new Error('the "filename" option is required for caching');


### PR DESCRIPTION
Using it as a local in `jade.compile()({lexer: 'blah'})` is still supported.

See #1392.
