### PR TITLE
Fix empty text-only block case

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -811,7 +811,7 @@ Parser.prototype = {
 
     // block?
     if (tag.textOnly) {
-      tag.block = this.parseTextBlock();
+      tag.block = this.parseTextBlock() || new nodes.Block();
     } else if ('indent' == this.peek().type) {
       var block = this.block();
       for (var i = 0, len = block.nodes.length; i < len; ++i) {

--- a/test/cases/text.html
+++ b/test/cases/text.html
@@ -1,4 +1,6 @@
 <option value="">-- (selected) --</option>
+<p></p>
+<p></p>
 <p>
   foo
   bar

--- a/test/cases/text.jade
+++ b/test/cases/text.jade
@@ -1,6 +1,10 @@
 option(value='') -- (selected) --
 
 p
+
+p.
+
+p
   | foo
   | bar
   | baz


### PR DESCRIPTION
#1743

`parseTextBlock()` can return undefined sometimes, so we need to handle that
