### PR TITLE
Use default 2-space indentation for all non-string true-y values

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -35,7 +35,7 @@ var Compiler = module.exports = function Compiler(node, options) {
   this.hasCompiledDoctype = false;
   this.hasCompiledTag = false;
   this.pp = options.pretty || false;
-  if (this.pp === true) {
+  if (this.pp && typeof this.pp !== 'string') {
     this.pp = '  ';
   }
   this.debug = false !== options.compileDebug;


### PR DESCRIPTION
Fixes #1755.
