### PR TITLE
package.json: Use real names and add current maintainers

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,13 @@
   "version": "1.8.1",
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "maintainers": [
-    "forbeslindesay <forbes@lindesay.co.uk>",
-    "bloodyowl <mlbli@me.com",
-    "jbnicolai <joshua@jbna.nl>"
+    "Forbes Lindesay <forbes@lindesay.co.uk>",
+    "Matthias Le Brun <mlbli@me.com>",
+    "Joshua Appelman <joshua@jbna.nl>",
+    "Jonathan Ong <jonathanrichardong@gmail.com>",
+    "Alex Kocharin <alex@kocharin.ru>",
+    "Hemanth <hemanth.hm@gmail.com>",
+    "Timothy Gu <timothygu99@gmail.com>"
   ],
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
This makes our npm page look more maintained.

Using real names are specified by https://www.npmjs.org/doc/files/package.json.html#people-fields-author-contributors

Some maintainers are not added because:
- the person is the author, or
- the person chose to be private in the jadejs organization.

Conversely, some private maintainers are in the package.json because they were already in it when I got it.
