### PR TITLE
Remove dependency on monocle

### DIFF
--- a/bin/jade.js
+++ b/bin/jade.js
@@ -12,7 +12,6 @@ var fs = require('fs')
   , resolve = path.resolve
   , exists = fs.existsSync || path.existsSync
   , join = path.join
-  , monocle = require('monocle')()
   , mkdirp = require('mkdirp')
   , jade = require('../');
 
@@ -106,16 +105,21 @@ var files = program.args;
 if (files.length) {
   console.log();
   if (options.watch) {
-    // keep watching when error occured.
-    process.on('uncaughtException', function(err) {
-      console.error(err);
-    });
-    files.forEach(renderFile);
-    monocle.watchFiles({
-      files: files,
-      listener: function(file) {
-        renderFile(file.absolutePath);
+    files.forEach(function(filename) {
+      try {
+        renderFile(filename);
+      } catch (ex) {
+        // keep watching when error occured.
+        console.error(ex.stack || ex.message || ex);
       }
+      fs.watchFile(filename, {persistent: true, interval: 200}, function (filename) {
+        try {
+          renderFile(filename);
+        } catch (ex) {
+          // keep watching when error occured.
+          console.error(ex.stack || ex.message || ex);
+        }
+      });
     });
   } else {
     files.forEach(renderFile);

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "commander": "~2.5.0",
     "constantinople": "~3.0.1",
     "mkdirp": "~0.5.0",
-    "monocle": "1.1.51",
     "transformers": "2.1.0",
     "void-elements": "~1.0.0",
     "with": "~4.0.0"


### PR DESCRIPTION
This is primarily to fix installation of jade on node@0.8

I've also fixed the slightly odd usage of process.on uncaught exception.

I don't think we were getting much from using monocle as it appears only to use `fs.watch` on Windows and everywhere else it just polls.  We may as well poll everywhere.  The other thing I think it was doing was some kind of parent directory watching, but I find the code to monocle really hard to digest, perhaps @samccone could give us some advice?

Once the work on the linker is done, we should be able to build an even better watcher that watches dependencies etc.
