### PR TITLE
remove duplicate 'require' on 'utils'.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,7 @@ exports.filters = require('./filters');
  * Utilities.
  */
 
-exports.utils = require('./utils');
+exports.utils = utils;
 
 /**
  * Expose `Compiler`.


### PR DESCRIPTION
use
     exports.utils = utils;
instead of
     exports.utils = require('./utils');
since 'utils' has been require before.
