### PR TITLE
Add plugin infrastructure

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,7 @@
 
 var fs = require('fs');
 var path = require('path');
+var resolve = require('resolve').sync;
 var lex = require('jade-lexer');
 var stripComments = require('jade-strip-comments');
 var parse = require('jade-parser');
@@ -52,14 +53,60 @@ function compileBody(str, options){
   var debug_sources = {};
   debug_sources[options.filename] = str;
   var dependencies = [];
+  var plugins = options.plugins || [];
+  plugins = plugins.map(function (plugin) {
+    if (typeof plugin === 'string') {
+      var opts = {
+        basedir: path.dirname(module.parent.filename)
+      };
+      // Test if plugin name is local (i.e. `./my-plugin`)
+      // Regex from https://github.com/substack/node-resolve/blob/5cae82fb22cb64d5b72f703c787dc0fd418ed412/lib/sync.js#L21
+      if (/^(?:\.\.?(?:\/|$)|\/|([A-Za-z]:)?[\\\/])/.test(plugin)) {
+        return require(resolve(plugin, opts))();
+      } else {
+        return require(resolve('jade-plugin-' + plugin, opts))();
+      }
+    }
+    return plugin;
+  });
+
   try {
     var ast = load.string(str, options.filename, {
-      lex: lex,
+      lex: function (str, filename) {
+        getPlugin('preLex').forEach(function (func) {
+          str = func(str);
+        });
+        var tokens = lex(str, filename, {
+          plugins: getPlugin('lex')
+        });
+        getPlugin('postLex').forEach(function (func) {
+          tokens = func(tokens);
+        });
+        return tokens;
+      },
       parse: function (tokens, filename) {
+        getPlugin('preParse').forEach(function (func) {
+          tokens = func(tokens);
+        });
         tokens = stripComments(tokens, { filename: filename });
-        return parse(tokens, filename);
+        var ast = parse(tokens, filename, {
+          plugins: getPlugin('parse')
+        });
+        getPlugin('postParse').forEach(function (func) {
+          ast = func(ast);
+        });
+
+        getPlugin('preLoad').forEach(function (func) {
+          ast = func(ast);
+        });
+        return ast;
       },
       resolve: function (filename, source) {
+        var plugins = getPlugin('loadResolve');
+        for (var i = 0; i < plugins.length; i++) {
+          var result = plugins[i](filename, source, options);
+          if (result) return result;
+        }
         filename = filename.trim();
         if (filename[0] !== '/' && !source)
           throw new Error('the "filename" option is required to use includes and extends with "relative" paths');
@@ -74,15 +121,40 @@ function compileBody(str, options){
         return filename;
       },
       read: function (filename) {
+        var str;
+        var plugins = getPlugin('loadRead');
+        for (var i = 0; i < plugins.length; i++) {
+          str = plugins[i](filename, source, options, dependencies);
+          if (str) {
+            debug_sources[filename] = str;
+            return str;
+          }
+        }
         dependencies.push(filename);
-        var str = fs.readFileSync(filename, 'utf8');
+        str = fs.readFileSync(filename, 'utf8');
         debug_sources[filename] = str;
         return str;
       }
     });
-    ast = filters.handleFilters(ast, exports.filters);
-    ast = link(ast);
+    getPlugin('postLoad').forEach(function (func) {
+      ast = func(ast);
+    });
 
+    ast = filters.handleFilters(ast, exports.filters);
+
+    getPlugin('preLink').forEach(function (func) {
+      ast = func(ast);
+    });
+    ast = link(ast, {
+      plugins: plugins
+    });
+    getPlugin('postLink').forEach(function (func) {
+      ast = func(ast);
+    });
+
+    getPlugin('preCodeGen').forEach(function (func) {
+      ast = func(ast);
+    });
     // Compile
     var js = generateCode(ast, {
       pretty: options.pretty,
@@ -93,6 +165,9 @@ function compileBody(str, options){
       self: options.self,
       includeSources: options.includeSources ? debug_sources : false,
       templateName: options.templateName
+    });
+    getPlugin('postCodeGen').forEach(function (func) {
+      js = func(js);
     });
 
     // Debug compiler
@@ -111,6 +186,16 @@ function compileBody(str, options){
       );
     }
     throw err;
+  }
+
+  function getPlugin(hook) {
+    var out = [];
+    for (var i = 0; i < plugins.length; i++) {
+      if (plugins[i][hook]) {
+        out.push(plugins[i][hook]);
+      }
+    }
+    return out;
   }
 }
 
@@ -172,7 +257,8 @@ exports.compile = function(str, options){
     self: options.self,
     includeSources: options.compileDebug === true,
     debug: options.debug,
-    templateName: 'template'
+    templateName: 'template',
+    plugins: options.plugins
   });
 
   var res = options.inlineRuntimeFunctions
@@ -215,7 +301,8 @@ exports.compileClientWithDependenciesTracked = function(str, options){
     self: options.self,
     includeSources: options.compileDebug,
     debug: options.debug,
-    templateName: options.name || 'template'
+    templateName: options.name || 'template',
+    plugins: options.plugins
   });
 
   return {body: parsed.body, dependencies: parsed.dependencies};

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "jade-load": "0.0.4",
     "jade-parser": "0.0.9",
     "jade-runtime": "^2.0.0",
-    "jade-strip-comments": "^1.0.0"
+    "jade-strip-comments": "^1.0.0",
+    "resolve": "^1.1.6"
   },
   "devDependencies": {
     "browserify": "*",


### PR DESCRIPTION
This is a work-in-progress. Two plugins I have made are available here:

- [jadejs/jade-plugin-debug-line](https://github.com/jadejs/jade-plugin-debug-line)
- [jadejs/jade-plugin-dynamic-include](https://github.com/jadejs/jade-plugin-dynamic-include)

To use these two plugins, first clone them. Assuming that they are cloned in directories parallel to the `jade` directory (which of course has this `plugins` branch checked out), and assuming that you are in the `jade` directory, try the following.

```js
var fs = require('fs');
var jade = require('.');
var str;

// sources
fs.writeFileSync('my-jade-src.jade', 'p hey');
fs.writeFileSync('interesting-styles.css', 'body { background-color: black; color: white }');
fs.writeFileSync('includer.jade', "- var file = 'interesting-styles'\nstyle\n  dyninclude #{file}.css\n- file = 'my-jade-src'\ndyninclude #{file}.jade");


// debug-line
str = jade.renderFile('my-jade-src.jade', {
  plugins: ['../jade-plugin-debug-line'] // once the module is published one can simply use `['debug-line']`
});
console.log(str);
// <p data-jade-file="my-jade-src.jade" data-jade-line="1">hey</p>


// dynamic-include
str = jade.renderFile('includer.jade', {
  plugins: [
    '../jade-plugin-dynamic-include'
  ],
  // unfortunately `require` is not available inside a dynamically-generated function, so have to pass in these two as locals
  fs,
  jadeSelf: jade
});
console.log(str);
// <style>body { background-color: black; color: white }</style><p>hey</p>
```

Unimplemented hooks:

- linker plugins
- code generator plugins