### PR TITLE
chore(deps): updated transformers because of node security warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "constantinople": "~3.0.1",
     "jstransformer": "0.0.2",
     "mkdirp": "~0.5.0",
-    "transformers": "2.1.0",
+    "transformers": "3.1.0",
     "uglify-js": "^2.4.19",
     "void-elements": "~2.0.1",
     "with": "~4.0.0"


### PR DESCRIPTION
Hey there,

I just updated this, because transformers 2.1.0, the version referenced is pulling uglify-js 2.2.5, and that version of uglify-js has security issues according to nodesecurity:
https://nodesecurity.io/advisories/39

We're still on the 1.x branch of jade, can you please merge and release this as a fix?

Thanks
Jozsef