### PR TITLE
Accept filters as an option rather than defined on exports

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -74,7 +74,7 @@ function compileBody(str, options){
       return str;
     }
   });
-  ast = filters.handleFilters(ast, options.filters);
+  ast = filters.handleFilters(ast, options.filters, options.filterOptions);
   ast = link(ast);
 
   // Compile
@@ -156,7 +156,8 @@ exports.compile = function(str, options){
     includeSources: options.compileDebug === true,
     debug: options.debug,
     templateName: 'template',
-    filters: options.filters
+    filters: options.filters,
+    filterOptions: options.filterOptions
   });
 
   var res = options.inlineRuntimeFunctions
@@ -200,7 +201,8 @@ exports.compileClientWithDependenciesTracked = function(str, options){
     includeSources: options.compileDebug,
     debug: options.debug,
     templateName: options.name || 'template',
-    filters: options.filters
+    filters: options.filters,
+    filterOptions: options.filterOptions
   });
 
   return {body: parsed.body, dependencies: parsed.dependencies};

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,11 +35,6 @@ exports.runtime = runtime;
 exports.cache = {};
 
 /**
- * Object for custom filters
- */
-exports.filters = {};
-
-/**
  * Compile the given `str` of pug and return a function body.
  *
  * @param {String} str
@@ -79,7 +74,7 @@ function compileBody(str, options){
       return str;
     }
   });
-  ast = filters.handleFilters(ast, exports.filters);
+  ast = filters.handleFilters(ast, options.filters);
   ast = link(ast);
 
   // Compile
@@ -160,7 +155,8 @@ exports.compile = function(str, options){
     self: options.self,
     includeSources: options.compileDebug === true,
     debug: options.debug,
-    templateName: 'template'
+    templateName: 'template',
+    filters: options.filters
   });
 
   var res = options.inlineRuntimeFunctions
@@ -203,7 +199,8 @@ exports.compileClientWithDependenciesTracked = function(str, options){
     self: options.self,
     includeSources: options.compileDebug,
     debug: options.debug,
-    templateName: options.name || 'template'
+    templateName: options.name || 'template',
+    filters: options.filters
   });
 
   return {body: parsed.body, dependencies: parsed.dependencies};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pug",
   "description": "A clean, whitespace-sensitive template language for writing HTML",
-  "version": "1.11.0",
+  "version": "2.0.0-alpha1",
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "maintainers": [
     "Forbes Lindesay <forbes@lindesay.co.uk>",

--- a/test/pug.test.js
+++ b/test/pug.test.js
@@ -17,12 +17,6 @@ try {
 
 describe('pug', function(){
 
-  describe('.properties', function(){
-    it('should have exports', function(){
-      assert.equal('object', typeof pug.filters, 'exports.filters missing');
-    });
-  });
-
   describe('unit tests with .render()', function(){
     it('should support doctypes', function(){
       assert.equal('<?xml version="1.0" encoding="utf-8" ?>', pug.render('doctype xml'));
@@ -1096,8 +1090,10 @@ describe('pug', function(){
 
   describe('filter indentation', function () {
     it('is maintained', function () {
-      pug.filters.indents = function(str){
-        return str.split(/\n/).map(function (line) { return line.match(/^ */)[0].length; }).join(",");
+      var filters = {
+        indents: function(str){
+          return str.split(/\n/).map(function (line) { return line.match(/^ */)[0].length; }).join(",");
+        }
       };
 
       var indents = [
@@ -1119,7 +1115,7 @@ describe('pug', function(){
         '   x'
       ].join('\n');
 
-      assert.equal(pug.render(indents), '0,1,2,3,0,4,4,3,3,4,2,0,2,0,1');
+      assert.equal(pug.render(indents, {filters: filters}), '0,1,2,3,0,4,4,3,3,4,2,0,2,0,1');
     });
   });
 

--- a/test/run.js
+++ b/test/run.js
@@ -8,10 +8,12 @@ var assert = require('assert');
 var pug = require('../');
 var uglify = require('uglify-js');
 
-pug.filters['custom-filter'] = function (str, options) {
-  assert(str === 'foo bar');
-  assert(options.foo === 'bar');
-  return 'bar baz';
+var filters = {
+  ['custom-filter']: function (str, options) {
+    assert(str === 'foo bar');
+    assert(options.foo === 'bar');
+    return 'bar baz';
+  }
 };
 
 // test cases
@@ -34,7 +36,12 @@ cases.forEach(function(test){
   it(name, function(){
     var path = 'test/cases/' + test + '.pug';
     var str = fs.readFileSync(path, 'utf8');
-    var fn = pug.compile(str, { filename: path, pretty: true, basedir: 'test/cases' });
+    var fn = pug.compile(str, {
+      filename: path,
+      pretty: true,
+      basedir: 'test/cases',
+      filters: filters
+    });
     var actual = fn({ title: 'Pug' });
 
     fs.writeFileSync(__dirname + '/output/' + test + '.html', actual);
@@ -44,19 +51,22 @@ cases.forEach(function(test){
       filename: path,
       pretty: true,
       compileDebug: false,
-      basedir: 'test/cases'
+      basedir: 'test/cases',
+      filters: filters
     }), {output: {beautify: true}, mangle: false, compress: false, fromString: true}).code;
     var clientCodeDebug = uglify.minify(pug.compileClient(str, {
       filename: path,
       pretty: true,
       compileDebug: true,
-      basedir: 'test/cases'
+      basedir: 'test/cases',
+      filters: filters
     }), {output: {beautify: true}, mangle: false, compress: false, fromString: true}).code;
     fs.writeFileSync(__dirname + '/output/' + test + '.js', uglify.minify(pug.compileClient(str, {
       filename: path,
       pretty: false,
       compileDebug: false,
-      basedir: 'test/cases'
+      basedir: 'test/cases',
+      filters: filters
     }), {output: {beautify: true}, mangle: false, compress: false, fromString: true}).code);
     if (/filter/.test(test)) {
       actual = actual.replace(/\n| /g, '');
@@ -95,7 +105,12 @@ describe('certain syntax is not allowed and will throw a compile time error', fu
       var path = 'test/anti-cases/' + test + '.pug';
       var str = fs.readFileSync(path, 'utf8');
       try {
-        var fn = pug.compile(str, { filename: path, pretty: true, basedir: 'test/anti-cases' });
+        var fn = pug.compile(str, {
+          filename: path,
+          pretty: true,
+          basedir: 'test/anti-cases',
+          filters: filters
+        });
       } catch (ex) {
         assert(ex instanceof Error, 'Should throw a real Error');
         assert(ex.code.indexOf('PUG:') === 0, 'It should have a code of "PUG:SOMETHING"');

--- a/test/run.js
+++ b/test/run.js
@@ -9,7 +9,7 @@ var pug = require('../');
 var uglify = require('uglify-js');
 
 var filters = {
-  ['custom-filter']: function (str, options) {
+  'custom-filter': function (str, options) {
     assert(str === 'foo bar');
     assert(options.foo === 'bar');
     return 'bar baz';


### PR DESCRIPTION
This will fix the fairly common issue where people add a custom filter
to one version of pug but then use a different version to do the
rendering (via something like a gulp/grunt plugin).