### PR TITLE
Note: Pug CLI has been split into a separate node module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ which will produce `filename.js` containing the compiled template.
 After installing the latest version of [node](http://nodejs.org/), install with:
 
 ```console
-$ npm install pug -g
+$ npm install pug-cli -g
 ```
 
 and run with


### PR DESCRIPTION
...So you can't use Pug directly from your commandline shell without installing `pug-cli`.

This update is in response to GitHub issue #2295.