### PR TITLE
Fix including pug files with an implicit extension

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -50,29 +50,27 @@ function compileBody(str, options){
   var ast = load.string(str, options.filename, {
     lex: lex,
     parse: function (tokens, filename) {
+      tokens = tokens.map(function (token) {
+        if (token.type === 'path' && token.val.indexOf('.') === -1) {
+          return {
+            type: 'path',
+            line: token.line,
+            col: token.col,
+            val: token.val + '.pug'
+          };
+        }
+        return token;
+      });
       tokens = stripComments(tokens, { filename: filename });
       return parse(tokens, filename);
-    },
-    resolve: function (filename, source) {
-      filename = filename.trim();
-      if (filename[0] !== '/' && !source)
-        throw new Error('the "filename" option is required to use includes and extends with "relative" paths');
-
-      if (filename[0] === '/' && !options.basedir)
-        throw new Error('the "basedir" option is required to use includes and extends with "absolute" paths');
-
-      filename = path.join(filename[0] === '/' ? options.basedir : path.dirname(source), filename);
-
-      if (path.basename(filename).indexOf('.') === -1) filename += '.pug';
-
-      return filename;
     },
     read: function (filename) {
       dependencies.push(filename);
       var str = fs.readFileSync(filename, 'utf8');
       debug_sources[filename] = str;
       return str;
-    }
+    },
+    basedir: options.basedir
   });
   ast = filters.handleFilters(ast, options.filters, options.filterOptions);
   ast = link(ast);

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "pug-filters": "1.1.1",
     "pug-lexer": "1.0.0",
     "pug-linker": "0.0.4",
-    "pug-loader": "1.0.0",
+    "pug-loader": "1.0.2",
     "pug-parser": "1.0.0",
     "pug-runtime": "2.0.0",
     "pug-strip-comments": "0.0.1"


### PR DESCRIPTION
By adding `.pug` directly to the path token, we ensure that it is still
recognised as an Include rather than a RawInclude.

Fixes #2308 and #2281