### PR TITLE
use native path module to parse include/extends file extension

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -51,7 +51,7 @@ function compileBody(str, options){
     lex: lex,
     parse: function (tokens, filename) {
       tokens = tokens.map(function (token) {
-        if (token.type === 'path' && token.val.indexOf('.') === -1) {
+        if (token.type === 'path' && path.extname(token.val) === '') {
           return {
             type: 'path',
             line: token.line,

--- a/test/cases/auxiliary/extends-relative.pug
+++ b/test/cases/auxiliary/extends-relative.pug
@@ -1,0 +1,4 @@
+extends ../../cases/auxiliary/layout
+
+block content
+    include ../../cases/auxiliary/include-from-root

--- a/test/cases/include-extends-relative.html
+++ b/test/cases/include-extends-relative.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <title>My Application</title>
+  </head>
+  <body>
+    <h1>hello</h1>
+  </body>
+</html>

--- a/test/cases/include-extends-relative.pug
+++ b/test/cases/include-extends-relative.pug
@@ -1,0 +1,1 @@
+include ../cases/auxiliary/extends-relative.pug


### PR DESCRIPTION
Hello,

The [current test for `'.'` in the path](https://github.com/pugjs/pug/commit/433e2ab18b3aabe7b34947489f799c0390aa0ac4) excludes all paths with a `.` including `../`, breaking some relative paths.  I've written tests to demonstrate this case.  First I am pushing the tests which fail, then the fix which passes.

Thanks for your work!