### PR TITLE
parse inline tags as block

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -62,7 +62,7 @@ function compileBody(str, options){
         return token;
       });
       tokens = stripComments(tokens, { filename: filename });
-      return parse(tokens, filename);
+      return parse(tokens, filename, undefined, options.inlineAsBlock);
     },
     read: function (filename) {
       dependencies.push(filename);
@@ -143,6 +143,7 @@ exports.compile = function(str, options){
   str = String(str);
 
   var parsed = compileBody(str, {
+    inlineAsBlock: options.inlineAsBlock,
     compileDebug: options.compileDebug !== false,
     filename: options.filename,
     basedir: options.basedir,
@@ -188,6 +189,7 @@ exports.compileClientWithDependenciesTracked = function(str, options){
 
   str = String(str);
   var parsed = compileBody(str, {
+    inlineAsBlock: options.inlineAsBlock,
     compileDebug: options.compileDebug,
     filename: options.filename,
     basedir: options.basedir,


### PR DESCRIPTION
is it possible to add an option that can be controlled manually, as "pretty" option, to be able to render inline elements as block?

my suggestion:
```
{
  "inlineAsBlock": true | false | undefined
}
```

for example:
"inlineAsBlock": false or undefined --- will not affect and render like this ▼
```
<ul>
	<li><a href="same.html">Lorem ipsum dolor.</a> <strong>maxime, dolores.</<strong></li>
</ul>
```

and "inlineAsBlock": true --- will render like this ▼
```
<ul>
	<li>
		<a href="same.html">Lorem ipsum dolor.</a>
		<strong>maxime, dolores.</<strong>
	</li>
</ul>
```


changes are also needed in
[pug-parser/index.js](https://github.com/pugjs/pug-parser/blob/master/index.js)