### PR TITLE
Regression test for extends

### DIFF
--- a/test/cases/auxiliary/layout
+++ b/test/cases/auxiliary/layout
@@ -1,0 +1,13 @@
+doctype html
+html
+  head
+    title Something has gone wrong
+
+  body
+    block header
+      p
+      p
+        a(href='/') Home
+
+
+    block content

--- a/test/cases/regression.2336.html
+++ b/test/cases/regression.2336.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Something has gone wrong</title>
+  </head>
+  <body>
+    <p></p>
+    <p><a href="/">Home</a></p>
+    <h1>What is the title</h1>
+  </body>
+</html>

--- a/test/cases/regression.2336.pug
+++ b/test/cases/regression.2336.pug
@@ -1,0 +1,4 @@
+extends ../cases/auxiliary/layout
+
+block content
+   h1 What is the title


### PR DESCRIPTION
Test that shows that extends ../layout fails to include the file in
pug@2.0.0-alpha7 which worked in pug@2.0.0-alpha3 see
https://github.com/pugjs/pug/issues/2336