### PR TITLE
Expose the `filters` option as a global export

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -78,16 +78,16 @@ function compileBody(str, options){
     },
     basedir: options.basedir
   });
-  var filters = {};
+  var filtersSet = {};
   Object.keys(exports.filters).forEach(function (key) {
-    filters[key] = exports.filters[key];
+    filtersSet[key] = exports.filters[key];
   });
   if (options.filters) {
     Object.keys(options.filters).forEach(function (key) {
-      filters[key] = options.filters[key];
+      filtersSet[key] = options.filters[key];
     });
   }
-  ast = filters.handleFilters(ast, filters, options.filterOptions);
+  ast = filters.handleFilters(ast, filtersSet, options.filterOptions);
   ast = link(ast);
 
   // Compile

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,6 +35,12 @@ exports.runtime = runtime;
 exports.cache = {};
 
 /**
+ * Object for global custom filters.  Note that you can also just pass a `filters`
+ * option to any other method.
+ */
+exports.filters = {};
+
+/**
  * Compile the given `str` of pug and return a function body.
  *
  * @param {String} str
@@ -72,7 +78,16 @@ function compileBody(str, options){
     },
     basedir: options.basedir
   });
-  ast = filters.handleFilters(ast, options.filters, options.filterOptions);
+  var filters = {};
+  Object.keys(exports.filters).forEach(function (key) {
+    filters[key] = exports.filters[key];
+  });
+  if (options.filters) {
+    Object.keys(options.filters).forEach(function (key) {
+      filters[key] = options.filters[key];
+    });
+  }
+  ast = filters.handleFilters(ast, filters, options.filterOptions);
   ast = link(ast);
 
   // Compile


### PR DESCRIPTION
This helps keep a closer match to the 1.0.0 API, thus an easier upgrade
path.

[closes #2360]