### PR TITLE
+ 2.0 alpha history note

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+2.0.0-alpha / 2016
+
+  * Better comment handling
+  * See **[Breaking Changes](https://github.com/pugjs/pug/issues/2305)**
+
 1.11.0 / 2015-06-12
 ==================
 


### PR DESCRIPTION
gulp-pug 3.x with pug 2.0.0-alpha is on npm, & finding info about pug's changes takes too much effort.  Since the code updates are on this branch, so should the doc updates IMHO.

Not meant to be permanent; just to help folks for the next few weeks/months while you ramp up docs.