### PR TITLE
'else' block removed from findReplacementFunc

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -53,9 +53,8 @@ function findReplacementFunc(plugins, name) {
     throw new Error('Two or more plugins all implement ' + name + ' method.');
   } else if (eligiblePlugins.length) {
     return eligiblePlugins[0][name];
-  } else {
-    return null;
   }
+  return null;
 }
 
 /**


### PR DESCRIPTION
The 'else' block was not needed, thus it was removed. 'return null' after the conditionals.