### PR TITLE
Correct README to use beta instead of alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This project was formerly known as "Jade." However, it has been revealed to us t
 
 If your package or app currently uses `jade`, don't worry: we have secured permissions to continue to occupy that package name, although all new versions will be released under `pug`.
 
-Pug 2.0.0 is still under alpha stage, and there are several syntactic differences we have deprecated and removed. Such differences are documented at [#2305](https://github.com/pugjs/pug/issues/2305).
+Pug 2.0.0 is still under beta stage, and there are several syntactic differences we have deprecated and removed. Such differences are documented at [#2305](https://github.com/pugjs/pug/issues/2305).
 
 The website and documentation for Pug are still being updated, but if you are new to Pug, you should get started with the new syntax and install the Pug package on npm.
 


### PR DESCRIPTION
Noticed that the README still mentions alpha when pug@2 is currently in beta. This updates the README to reflect that. 