### PR TITLE
fix a problem when use option -H on Windows

### DIFF
--- a/bin/jade.js
+++ b/bin/jade.js
@@ -254,7 +254,7 @@ function renderFile(path, rootPath) {
       // prepend output directory
       if (rootPath && program.hierarchy) {
         // replace the rootPath of the resolved path with output directory
-        path = resolve(path).replace(new RegExp('^' + resolve(rootPath)), '');
+        path = relative(rootPath, path);
         path = join(program.out, path);
       } else {
         if (rootPath && !hierarchyWarned) {

--- a/bin/jade.js
+++ b/bin/jade.js
@@ -10,6 +10,7 @@ var fs = require('fs')
   , basename = path.basename
   , dirname = path.dirname
   , resolve = path.resolve
+  , relative = path.relative
   , normalize = path.normalize
   , join = path.join
   , mkdirp = require('mkdirp')


### PR DESCRIPTION
Hi, I'm Shengjie.
When I use `Jade` with the option `-H`, It works very well on `Linux`, but throws errors on `Windows`.And I find that the problem was at the function `renderFile` in the file — bin/jade.js as below:
```Javascript
 // replace the rootPath of the resolved path with output directory
path = resolve(path).replace(new RegExp('^' + resolve(rootPath)), '');
path = join(program.out, path);
```
As we know, `Path.seq` of module `Path` is '/' on `Linux` but '\' on `Windows` ,so when we use method `Path.resolve` and then use `RegExp` constructor with this result to build an `RegExp` object, it makes differences.For example,
```Javascript
var resolve = require('path').resolve;
var path = '/home/Jack/test/index.js';
var rootPath = '/home/Jack';
var reg = new RegExp('^'+resolve(rootPath));
console.log(reg.test(resolve(path))); //the result is true on Linux,but false on Windows
```
Just considering about `Windows`, we imagine that the volumn is `D:\`. So the result of `resolve(rootPath)` is `D:\home\Jack\` and `reg` is `/^D:\home\Jack/`.Absolutely, `reg` can't match the string in `path` and error comes.
I use `Path.relative` to get the relative path from `rootPath` to `path`, and it' works well.