### PR TITLE
Fix doesn't support multiple dots in file name

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -95,7 +95,9 @@ function compileBody(str, options){
     },
     parse: function (tokens, options) {
       tokens = tokens.map(function (token) {
-        if (token.type === 'path' && path.extname(token.val) === '') {
+        var extname = path.extname(token.val);
+        if (token.type === 'path' && 
+          (extname === '' || ['.jade', '.pug'].indexOf(extname) < 0)) {
           return {
             type: 'path',
             line: token.line,


### PR DESCRIPTION
Fix Issue:

> Doesn't support multiple dots in file name while extending

See [pug-loader/issues#59](https://github.com/pugjs/pug-loader/issues/59)