### PR TITLE
add larpug package to additional resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Tutorials:
 
 Implementations in other languages:
 
+  - [Larpug - Pug for Laravel](https://github.com/acidjazz/larpug)
   - [php](https://github.com/pug-php/pug)
   - [scala](https://scalate.github.io/scalate/documentation/scaml-reference.html)
   - [ruby](https://github.com/slim-template/slim)
@@ -151,7 +152,6 @@ Implementations in other languages:
 
 Other:
 
-  - [Larpug - Pug for Laravel](https://github.com/acidjazz/larpug)
   - [Emacs Mode](https://github.com/brianc/jade-mode)
   - [Vim Syntax](https://github.com/digitaltoad/vim-pug)
   - [TextMate Bundle](http://github.com/miksago/jade-tmbundle)

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Implementations in other languages:
 
 Other:
 
+  - [Larpug - Pug for Laravel](https://github.com/acidjazz/larpug)
   - [Emacs Mode](https://github.com/brianc/jade-mode)
   - [Vim Syntax](https://github.com/digitaltoad/vim-pug)
   - [TextMate Bundle](http://github.com/miksago/jade-tmbundle)


### PR DESCRIPTION
I'd like to add my [laravel pug package](https://github.com/acidjazz/larpug) to the list of additional resources. I Finally got my tests to hit 100% coverage and I've been using this for long enough now to be happy w/ its stability.

Also its not a PHP re-write, it actually uses Pug :)