### PR TITLE
Bind plugin function to plugin itself in findReplacementFunc()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -52,7 +52,7 @@ function findReplacementFunc(plugins, name) {
   if (eligiblePlugins.length > 1) {
     throw new Error('Two or more plugins all implement ' + name + ' method.');
   } else if (eligiblePlugins.length) {
-    return eligiblePlugins[0][name];
+    return eligiblePlugins[0][name].bind(eligiblePlugins[0]);
   }
   return null;
 }


### PR DESCRIPTION
This is already implicitly done for the regular plugin path (`applyPlugins`).