### PR TITLE
Fix tests - pug-runtime now adds a trailing ; to inline styles #2537

### DIFF
--- a/test/cases-es2015/attr.html
+++ b/test/cases-es2015/attr.html
@@ -1,1 +1,1 @@
-<div class="avatar-div" style="background-image: url(https://www.gravatar.com/avatar/219b77f9d21de75e81851b6b886057c7)"></div>
+<div class="avatar-div" style="background-image: url(https://www.gravatar.com/avatar/219b77f9d21de75e81851b6b886057c7);"></div>

--- a/test/cases/styles.html
+++ b/test/cases/styles.html
@@ -7,14 +7,14 @@
     </style>
   </head>
   <body>
-    <div style="color:red;background:green"></div>
-    <div style="color:red;background:green"></div>
-    <div style="color:red;background:green"></div>
-    <div style="color:red;background:green"></div>
-        <div style="color:red;background:green"></div>
-        <div style="color:red;background:green"></div>
-    <div style="color:red;background:green"></div>
-    <div style="color:red;background:green"></div>
-        <div style="color:red;background:green"></div>
+    <div style="color:red;background:green;"></div>
+    <div style="color:red;background:green;"></div>
+    <div style="color:red;background:green;"></div>
+    <div style="color:red;background:green;"></div>
+        <div style="color:red;background:green;"></div>
+        <div style="color:red;background:green;"></div>
+    <div style="color:red;background:green;"></div>
+    <div style="color:red;background:green;"></div>
+        <div style="color:red;background:green;"></div>
   </body>
 </html>

--- a/test/pug.test.js
+++ b/test/pug.test.js
@@ -371,8 +371,8 @@ describe('pug', function(){
       assert.equal('<a href="http://google.com" title="Some : weird = title"></a>', pug.render('a(href= "http://google.com", title= "Some : weird = title")'));
       assert.equal('<label for="name"></label>', pug.render('label(for="name")'));
       assert.equal('<meta name="viewport" content="width=device-width"/>', pug.render("meta(name= 'viewport', content='width=device-width')"), 'Test attrs that contain attr separators');
-      assert.equal('<div style="color= white"></div>', pug.render("div(style='color= white')"));
-      assert.equal('<div style="color: white"></div>', pug.render("div(style='color: white')"));
+      assert.equal('<div style="color= white;"></div>', pug.render("div(style='color= white')"));
+      assert.equal('<div style="color: white;"></div>', pug.render("div(style='color: white')"));
       assert.equal('<p class="foo"></p>', pug.render("p('class'='foo')"), 'Test keys with single quotes');
       assert.equal('<p class="foo"></p>', pug.render("p(\"class\"= 'foo')"), 'Test keys with double quotes');
 
@@ -389,10 +389,10 @@ describe('pug', function(){
 
       assert.equal('<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>', pug.render('meta(http-equiv="X-UA-Compatible", content="IE=edge,chrome=1")'));
 
-      assert.equal('<div style="background: url(/images/test.png)">Foo</div>', pug.render("div(style= 'background: url(/images/test.png)') Foo"));
-      assert.equal('<div style="background = url(/images/test.png)">Foo</div>', pug.render("div(style= 'background = url(/images/test.png)') Foo"));
-      assert.equal('<div style="foo">Foo</div>', pug.render("div(style= ['foo', 'bar'][0]) Foo"));
-      assert.equal('<div style="bar">Foo</div>', pug.render("div(style= { foo: 'bar', baz: 'raz' }['foo']) Foo"));
+      assert.equal('<div style="background: url(/images/test.png);">Foo</div>', pug.render("div(style= 'background: url(/images/test.png)') Foo"));
+      assert.equal('<div style="background = url(/images/test.png);">Foo</div>', pug.render("div(style= 'background = url(/images/test.png)') Foo"));
+      assert.equal('<div style="foo;">Foo</div>', pug.render("div(style= ['foo', 'bar'][0]) Foo"));
+      assert.equal('<div style="bar;">Foo</div>', pug.render("div(style= { foo: 'bar', baz: 'raz' }['foo']) Foo"));
       assert.equal('<a href="def">Foo</a>', pug.render("a(href='abcdefg'.substr(3,3)) Foo"));
       assert.equal('<a href="def">Foo</a>', pug.render("a(href={test: 'abcdefg'}.test.substr(3,3)) Foo"));
       assert.equal('<a href="def">Foo</a>', pug.render("a(href={test: 'abcdefg'}.test.substr(3,[0,3][1])) Foo"));


### PR DESCRIPTION
This PR on pug tests is necessary to be compatible with the head of pug-runtime.

cf https://github.com/pugjs/pug-runtime/commit/8647d82f6faf41d7752056aef538b88c791ec29c
