### PR TITLE
Fixed register.js to replace "\" with "/" for Windows.

### DIFF
--- a/register.js
+++ b/register.js
@@ -1,5 +1,5 @@
 var pug = require('./');
-var resolvedPug = require.resolve('./');
+var resolvedPug = require.resolve('./').replace(/\\/g, '/');
 
 function compileTemplate(module, filename) {
   var template = pug.compileFileClient(filename, {inlineRuntimeFunctions: false});

--- a/register.js
+++ b/register.js
@@ -1,9 +1,9 @@
 var pug = require('./');
-var resolvedPug = require.resolve('./').replace(/\\/g, '/');
+var resolvedPug = JSON.stringify(require.resolve('./'));
 
 function compileTemplate(module, filename) {
   var template = pug.compileFileClient(filename, {inlineRuntimeFunctions: false});
-  var body = "var pug = require('" + resolvedPug + "').runtime;\n\n" +
+  var body = "var pug = require(" + resolvedPug + ").runtime;\n\n" +
              "module.exports = " + template + ";";
   module._compile(body, filename);
 }


### PR DESCRIPTION
Since require.resolve returns back-slashed directories in Windows, when it gets added as a string within a string (like it does in register.js) those back-slahes become escapes. Since node is perfectly happy forward-slashed directories in Windows, I just converted them.