### PR TITLE
Adds naming for detection of template engine

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,6 +23,12 @@ var runtime = require('pug-runtime');
 var runtimeWrap = require('pug-runtime/wrap');
 
 /**
+ * Name for detection
+ */
+ 
+exports.name = 'Pug';
+
+/**
  * Pug runtime helpers.
  */
 

--- a/test/pug.test.js
+++ b/test/pug.test.js
@@ -1155,4 +1155,10 @@ describe('pug', function(){
       ],info.dependencies);
     });
   });
+
+  describe('.name', function() {
+    it('should have a name attribute', function() {
+      assert.strictEqual(pug.name, 'Pug');
+    });
+  });
 });


### PR DESCRIPTION
Since there is not a `constructor` and thus a `constructor.name`
for detection this provides a name that can be used for the same
purpose. This is useful for application servers that allow the
template engine to be passed in.

I am working on PRs for other template engines for this as well.
It should also be noted that Handlebars, lodash, and underscore
are all detectable through this method already.

https://github.com/olado/doT/pull/216 is a PR for this in doT
ejs: https://github.com/mde/ejs/pull/220