### PR TITLE
[pug-filters] Apply options to nested filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "watch": "jest --watch"
   },
   "jest": {
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "snapshotSerializers": ["./scripts/filename-serializer.js"]
   }
 }

--- a/packages/pug-filters/test/__snapshots__/per-filter-options-applied-to-nested-filters.test.js.snap
+++ b/packages/pug-filters/test/__snapshots__/per-filter-options-applied-to-nested-filters.test.js.snap
@@ -1,0 +1,87 @@
+exports[`test per filter options are applied, even to nested filters 1`] = `
+Object {
+  "filename": "<basedir>/packages/pug-filters/test/per-filter-options-applied-to-nested-filters.test.js",
+  "line": 0,
+  "nodes": Array [
+    Object {
+      "attributeBlocks": Array [],
+      "attrs": Array [],
+      "block": Object {
+        "filename": "<basedir>/packages/pug-filters/test/per-filter-options-applied-to-nested-filters.test.js",
+        "line": 2,
+        "nodes": Array [
+          Object {
+            "attrs": Array [],
+            "block": Object {
+              "filename": "<basedir>/packages/pug-filters/test/per-filter-options-applied-to-nested-filters.test.js",
+              "line": 3,
+              "nodes": Array [
+                Object {
+                  "attrs": Array [],
+                  "block": Object {
+                    "filename": "<basedir>/packages/pug-filters/test/per-filter-options-applied-to-nested-filters.test.js",
+                    "line": 3,
+                    "nodes": Array [
+                      Object {
+                        "line": 4,
+                        "type": "Text",
+                        "val": "function myFunc(foo) {",
+                      },
+                      Object {
+                        "line": 5,
+                        "type": "Text",
+                        "val": "
+",
+                      },
+                      Object {
+                        "line": 5,
+                        "type": "Text",
+                        "val": "  return foo;",
+                      },
+                      Object {
+                        "line": 6,
+                        "type": "Text",
+                        "val": "
+",
+                      },
+                      Object {
+                        "line": 6,
+                        "type": "Text",
+                        "val": "}",
+                      },
+                    ],
+                    "type": "Block",
+                  },
+                  "filename": "<basedir>/packages/pug-filters/test/per-filter-options-applied-to-nested-filters.test.js",
+                  "line": 3,
+                  "name": "uglify-js",
+                  "type": "Text",
+                  "val": "function myFunc(n) {
+    return n;
+}",
+                },
+              ],
+              "type": "Block",
+            },
+            "filename": "<basedir>/packages/pug-filters/test/per-filter-options-applied-to-nested-filters.test.js",
+            "line": 3,
+            "name": "cdata",
+            "type": "Text",
+            "val": "<![CDATA[function myFunc(n) {
+    return n;
+}]]>",
+          },
+        ],
+        "type": "Block",
+      },
+      "filename": "<basedir>/packages/pug-filters/test/per-filter-options-applied-to-nested-filters.test.js",
+      "isInline": false,
+      "line": 2,
+      "name": "script",
+      "selfClosing": false,
+      "type": "Tag",
+    },
+  ],
+  "type": "Block",
+}
+`;

--- a/packages/pug-filters/test/per-filter-options-applied-to-nested-filters.test.js
+++ b/packages/pug-filters/test/per-filter-options-applied-to-nested-filters.test.js
@@ -1,0 +1,28 @@
+const lex = require('pug-lexer');
+const parse = require('pug-parser');
+const handleFilters = require('../').handleFilters;
+
+const customFilters = {};
+test('per filter options are applied, even to nested filters', () => {
+  const source = `
+script
+  :cdata:uglify-js
+    function myFunc(foo) {
+      return foo;
+    }
+  `;
+
+  const ast = parse(
+    lex(source, {filename: __filename}),
+    {filename: __filename, src: source}
+  );
+
+  const options = {
+    'uglify-js': {output: {beautify: true}},
+  };
+
+  const output = handleFilters(ast, customFilters, options);
+  expect(output).toMatchSnapshot();
+
+  // TODO: render with `options.filterOptions['uglify-js']`
+});

--- a/scripts/filename-serializer.js
+++ b/scripts/filename-serializer.js
@@ -1,0 +1,20 @@
+const path = require('path');
+const basedir = path.resolve(__dirname + '/..');
+
+// filename serializer that removes the basedir
+module.exports = {
+  test: function(val) {
+    return (
+      val && typeof val === 'object' && ('filename' in val) &&
+      val.filename.replace(/\\/g, '/').indexOf(basedir.replace(/\\/g, '/')) === 0
+    );
+  },
+  print: function(val, serialize, indent) {
+    const output = {};
+    for (var key in val) {
+      output[key] = val[key];
+    }
+    output.filename = '<basedir>' + output.filename.substr(basedir.length).replace(/\\/g, '/');
+    return serialize(output);
+  }
+};


### PR DESCRIPTION
Original fix authored by @zah

This is a simple bug fix.

``` pug
script
  :cdata-js:babel(presets=['es2015'])
    const myFunc = () => `This is ES2015 in a CD${'ATA'}`;
```

When nested filters are used, the inner filter (babel) was failing to obtain its options from the `options.filterOptions.babel` table.