### PR TITLE
Remove ES6 syntax from pug-linker

### DIFF
--- a/packages/pug-linker/index.js
+++ b/packages/pug-linker/index.js
@@ -94,7 +94,7 @@ function extend(parentBlocks, ast) {
       var parentBlockList = parentBlocks[node.name] ? flattenParentBlocks(parentBlocks[node.name]) : [];
       if (parentBlockList.length) {
         node.parents = parentBlockList;
-        parentBlockList.forEach(parentBlock => {
+        parentBlockList.forEach(function (parentBlock) {
           switch (node.mode) {
             case 'append':
               parentBlock.nodes = parentBlock.nodes.concat(node.nodes);


### PR DESCRIPTION
Change 'fat arrow' function into regular function syntax. This will
make it simpler for codebases to depend on pug if they are using older
versions of node.