### PR TITLE
[pug-lexer] Allow a colon to start an attribute

### DIFF
--- a/packages/pug-lexer/index.js
+++ b/packages/pug-lexer/index.js
@@ -1068,7 +1068,7 @@ Lexer.prototype = {
               if (!whitespaceRe.test(str[x])) {
                 // if it is a JavaScript punctuator, then assume that it is
                 // a part of the value
-                return !characterParser.isPunctuator(str[x]) || quoteRe.test(str[x]);
+                return !characterParser.isPunctuator(str[x]) || quoteRe.test(str[x]) || str[x] === ':';
               }
             }
           }


### PR DESCRIPTION
[closes #2454]

I don't think there's actually any harm in this.  I don't think there's any valid JavaScript **expression** with a colon in it at the top level (i.e. not inside a string/parentheses etc.).

This needs a test case