### PR TITLE
Add compileFileModule method

### DIFF
--- a/packages/pug-code-gen/index.js
+++ b/packages/pug-code-gen/index.js
@@ -146,7 +146,7 @@ Compiler.prototype = {
         ');' +
         '}';
     }
-    return buildRuntime(this.runtimeFunctionsUsed) + 'function ' + (this.options.templateName || 'template') + '(locals) {var pug_html = "", pug_mixins = {}, pug_interp;' + js + ';return pug_html;}';
+    return (this.options.module && !this.inlineRuntimeFunctions ? 'var pug = require("pug-runtime");' : '') + buildRuntime(this.runtimeFunctionsUsed) + 'function ' + (this.options.templateName || 'template') + '(locals) {var pug_html = "", pug_mixins = {}, pug_interp;' + js + ';return pug_html;}' + (this.options.module ? ' module.exports = ' + (this.options.templateName || 'template') + ';' : '');
   },
 
   /**

--- a/packages/pug-code-gen/index.js
+++ b/packages/pug-code-gen/index.js
@@ -146,7 +146,7 @@ Compiler.prototype = {
         ');' +
         '}';
     }
-    return (this.options.module && !this.inlineRuntimeFunctions ? 'var pug = require("pug-runtime");' : '') + buildRuntime(this.runtimeFunctionsUsed) + 'function ' + (this.options.templateName || 'template') + '(locals) {var pug_html = "", pug_mixins = {}, pug_interp;' + js + ';return pug_html;}' + (this.options.module ? ' module.exports = ' + (this.options.templateName || 'template') + ';' : '');
+    return buildRuntime(this.runtimeFunctionsUsed) + 'function ' + (this.options.templateName || 'template') + '(locals) {var pug_html = "", pug_mixins = {}, pug_interp;' + js + ';return pug_html;}';
   },
 
   /**

--- a/packages/pug/lib/index.js
+++ b/packages/pug/lib/index.js
@@ -276,6 +276,7 @@ exports.compile = function(str, options){
  *     the compiled template for better error messages.
  *   - `filename` used to improve errors when `compileDebug` is not `true` and to resolve imports/extends
  *   - `name` the name of the resulting function (defaults to "template")
+ *   - `module` when it is explicitly `true`, the source code include export module syntax
  *
  * @param {String} str
  * @param {Options} options
@@ -303,6 +304,7 @@ exports.compileClientWithDependenciesTracked = function(str, options){
     filterOptions: options.filterOptions,
     filterAliases: options.filterAliases,
     plugins: options.plugins,
+    module: options.module
   });
 
   return {body: parsed.body, dependencies: parsed.dependencies};

--- a/packages/pug/lib/index.js
+++ b/packages/pug/lib/index.js
@@ -181,8 +181,7 @@ function compileBody(str, options){
     globals: options.globals,
     self: options.self,
     includeSources: options.includeSources ? debug_sources : false,
-    templateName: options.templateName,
-    module: options.module
+    templateName: options.templateName
   });
   js = applyPlugins(js, options, plugins, 'postCodeGen');
 
@@ -304,11 +303,19 @@ exports.compileClientWithDependenciesTracked = function(str, options){
     filters: options.filters,
     filterOptions: options.filterOptions,
     filterAliases: options.filterAliases,
-    plugins: options.plugins,
-    module: options.module
+    plugins: options.plugins
   });
 
-  return {body: parsed.body, dependencies: parsed.dependencies};
+  var body = parsed.body;
+
+  if(options.module) {
+    if(!options.inlineRuntimeFunctions) {
+      body = 'var pug = require("pug-runtime");' + body;
+    }
+    body += ' module.exports = ' + (options.templateName || 'template') + ';';
+  }
+
+  return {body: body, dependencies: parsed.dependencies};
 };
 
 /**

--- a/packages/pug/lib/index.js
+++ b/packages/pug/lib/index.js
@@ -309,7 +309,7 @@ exports.compileClientWithDependenciesTracked = function(str, options){
   var body = parsed.body;
 
   if(options.module) {
-    if(!options.inlineRuntimeFunctions) {
+    if(options.inlineRuntimeFunctions === false) {
       body = 'var pug = require("pug-runtime");' + body;
     }
     body += ' module.exports = ' + (options.name || 'template') + ';';

--- a/packages/pug/lib/index.js
+++ b/packages/pug/lib/index.js
@@ -312,7 +312,7 @@ exports.compileClientWithDependenciesTracked = function(str, options){
     if(!options.inlineRuntimeFunctions) {
       body = 'var pug = require("pug-runtime");' + body;
     }
-    body += ' module.exports = ' + (options.templateName || 'template') + ';';
+    body += ' module.exports = ' + (options.name || 'template') + ';';
   }
 
   return {body: body, dependencies: parsed.dependencies};

--- a/packages/pug/lib/index.js
+++ b/packages/pug/lib/index.js
@@ -181,7 +181,8 @@ function compileBody(str, options){
     globals: options.globals,
     self: options.self,
     includeSources: options.includeSources ? debug_sources : false,
-    templateName: options.templateName
+    templateName: options.templateName,
+    module: options.module
   });
   js = applyPlugins(js, options, plugins, 'postCodeGen');
 

--- a/packages/pug/test/__snapshots__/pug.test.js.snap
+++ b/packages/pug/test/__snapshots__/pug.test.js.snap
@@ -1,0 +1,15 @@
+exports[`pug .compileClient() should support module syntax in pug.compileClient(str, options) when inlineRuntimeFunctions it false 1`] = `
+"var pug = require(\"pug-runtime\");function template(locals) {var pug_html = \"\", pug_mixins = {}, pug_interp;var pug_debug_filename, pug_debug_line;try {var self = locals || {};;pug_debug_line = 1;
+pug_html = pug_html + \"\\u003Cdiv class=\\\"bar\\\"\\u003E\";
+;pug_debug_line = 1;
+pug_html = pug_html + (pug.escape(null == (pug_interp = self.foo) ? \"\" : pug_interp)) + \"\\u003C\\u002Fdiv\\u003E\";} catch (err) {pug.rethrow(err, pug_debug_filename, pug_debug_line);};return pug_html;} module.exports = template;"
+`;
+
+exports[`pug .compileClient() should support module syntax in pug.compileClient(str, options) when inlineRuntimeFunctions it true 1`] = `
+"function pug_escape(e){var a=\"\"+e,t=pug_match_html.exec(a);if(!t)return e;var r,c,n,s=\"\";for(r=t.index,c=0;r<a.length;r++){switch(a.charCodeAt(r)){case 34:n=\"&quot;\";break;case 38:n=\"&amp;\";break;case 60:n=\"&lt;\";break;case 62:n=\"&gt;\";break;default:continue}c!==r&&(s+=a.substring(c,r)),c=r+1,s+=n}return c!==r?s+a.substring(c,r):s}
+var pug_match_html=/[\"&<>]/;
+function pug_rethrow(n,e,r,t){if(!(n instanceof Error))throw n;if(!(\"undefined\"==typeof window&&e||t))throw n.message+=\" on line \"+r,n;try{t=t||require(\"fs\").readFileSync(e,\"utf8\")}catch(e){pug_rethrow(n,null,r)}var i=3,a=t.split(\"\\n\"),o=Math.max(r-i,0),h=Math.min(a.length,r+i),i=a.slice(o,h).map(function(n,e){var t=e+o+1;return(t==r?\"  > \":\"    \")+t+\"| \"+n}).join(\"\\n\");throw n.path=e,n.message=(e||\"Pug\")+\":\"+r+\"\\n\"+i+\"\\n\\n\"+n.message,n}function template(locals) {var pug_html = \"\", pug_mixins = {}, pug_interp;var pug_debug_filename, pug_debug_line;try {var self = locals || {};;pug_debug_line = 1;
+pug_html = pug_html + \"\\u003Cdiv class=\\\"bar\\\"\\u003E\";
+;pug_debug_line = 1;
+pug_html = pug_html + (pug_escape(null == (pug_interp = self.foo) ? \"\" : pug_interp)) + \"\\u003C\\u002Fdiv\\u003E\";} catch (err) {pug_rethrow(err, pug_debug_filename, pug_debug_line);};return pug_html;} module.exports = template;"
+`;

--- a/packages/pug/test/pug.test.js
+++ b/packages/pug/test/pug.test.js
@@ -970,36 +970,37 @@ describe('pug', function(){
   });
 
   describe('.compileClient()', function () {
-    it('should support .pug.compileClient(str)', function () {
+    it('should support pug.compileClient(str)', function () {
       var src = fs.readFileSync(__dirname + '/cases/basic.pug');
       var expected = fs.readFileSync(__dirname + '/cases/basic.html', 'utf8').replace(/\s/g, '');
       var fn = pug.compileClient(src);
       fn = Function('pug', fn.toString() + '\nreturn template;')(pug.runtime);
       var actual = fn({name: 'foo'}).replace(/\s/g, '');
-      assert(actual === expected);
+      expect(actual).toBe(expected);
     });
-    it('should support .pug.compileClient(str, options)', function () {
+    it('should support pug.compileClient(str, options)', function () {
       var src = '.bar= self.foo';
       var fn = pug.compileClient(src, {self: true});
       fn = Function('pug', fn.toString() + '\nreturn template;')(pug.runtime);
       var actual = fn({foo: 'baz'});
-      assert(actual === '<div class="bar">baz</div>');
+      expect(actual).toBe('<div class="bar">baz</div>');
     });
-    it('should support module syntax .pug.compileClient(str, options) when inlineRuntimeFunctions its true', function () {
+    it('should support module syntax in pug.compileClient(str, options) when inlineRuntimeFunctions it true', function () {
       var src = '.bar= self.foo';
       var fn = pug.compileClient(src, {self: true, module: true, inlineRuntimeFunctions: true});
+      expect(fn).toMatchSnapshot();
       fs.writeFileSync(__dirname + '/temp/input-compileModuleFileClient.js', fn);
       var expected = '<div class="bar">baz</div>';
-      var fn = require(__dirname + '/temp/input-compileModuleFileClient.js')
-      assert(fn({foo: 'baz'}) === expected);
+      var fn = require(__dirname + '/temp/input-compileModuleFileClient.js');
+      expect(fn({foo: 'baz'})).toBe('<div class="bar">baz</div>');
     });
-    it('should support module syntax .pug.compileClient(str, options) when inlineRuntimeFunctions its false', function () {
+    it('should support module syntax in pug.compileClient(str, options) when inlineRuntimeFunctions it false', function () {
       var src = '.bar= self.foo';
       var fn = pug.compileClient(src, {self: true, module: true, inlineRuntimeFunctions: false});
+      expect(fn).toMatchSnapshot();
       fs.writeFileSync(__dirname + '/temp/input-compileModuleFileClient.js', fn);
-      var expected = '<div class="bar">baz</div>';
-      var fn = require(__dirname + '/temp/input-compileModuleFileClient.js')
-      assert(fn({foo: 'baz'}) === expected);
+      var fn = require(__dirname + '/temp/input-compileModuleFileClient.js');
+      expect(fn({foo: 'baz'})).toBe('<div class="bar">baz</div>');
     });
   });
 

--- a/packages/pug/test/pug.test.js
+++ b/packages/pug/test/pug.test.js
@@ -979,11 +979,19 @@ describe('pug', function(){
       assert(actual === expected);
     });
     it('should support .pug.compileClient(str, options)', function () {
-      var src = '.bar= self.foo'
+      var src = '.bar= self.foo';
       var fn = pug.compileClient(src, {self: true});
       fn = Function('pug', fn.toString() + '\nreturn template;')(pug.runtime);
       var actual = fn({foo: 'baz'});
       assert(actual === '<div class="bar">baz</div>');
+    });
+    it('should support module syntax .pug.compileClient(str, options)', function () {
+      var src = '.bar= self.foo';
+      var fn = pug.compileClient(src, {self: true, module: true, inlineRuntimeFunctions: false});
+      fs.writeFileSync(__dirname + '/temp/input-compileModuleFileClient.js', fn.toString());
+      var expected = '<div class="bar">baz</div>';
+      var fn = require(__dirname + '/temp/input-compileModuleFileClient.js')
+      assert(fn({foo: 'baz'}) === expected);
     });
   });
 

--- a/packages/pug/test/pug.test.js
+++ b/packages/pug/test/pug.test.js
@@ -985,10 +985,18 @@ describe('pug', function(){
       var actual = fn({foo: 'baz'});
       assert(actual === '<div class="bar">baz</div>');
     });
-    it('should support module syntax .pug.compileClient(str, options)', function () {
+    it('should support module syntax .pug.compileClient(str, options) when inlineRuntimeFunctions its true', function () {
+      var src = '.bar= self.foo';
+      var fn = pug.compileClient(src, {self: true, module: true, inlineRuntimeFunctions: true});
+      fs.writeFileSync(__dirname + '/temp/input-compileModuleFileClient.js', fn);
+      var expected = '<div class="bar">baz</div>';
+      var fn = require(__dirname + '/temp/input-compileModuleFileClient.js')
+      assert(fn({foo: 'baz'}) === expected);
+    });
+    it('should support module syntax .pug.compileClient(str, options) when inlineRuntimeFunctions its false', function () {
       var src = '.bar= self.foo';
       var fn = pug.compileClient(src, {self: true, module: true, inlineRuntimeFunctions: false});
-      fs.writeFileSync(__dirname + '/temp/input-compileModuleFileClient.js', fn.toString());
+      fs.writeFileSync(__dirname + '/temp/input-compileModuleFileClient.js', fn);
       var expected = '<div class="bar">baz</div>';
       var fn = require(__dirname + '/temp/input-compileModuleFileClient.js')
       assert(fn({foo: 'baz'}) === expected);


### PR DESCRIPTION
Add compileFileModule method. This method is very useful for compiling templates to modules compatible with node js in order to make a require. In this way, we can save the content in a file for later use as a standalone module or asynchronous cache.