### PR TITLE
[pug-lexer] Allow a colon to start an attribute

### DIFF
--- a/packages/pug-lexer/index.js
+++ b/packages/pug-lexer/index.js
@@ -1071,7 +1071,7 @@ Lexer.prototype = {
               if (!whitespaceRe.test(str[x])) {
                 // if it is a JavaScript punctuator, then assume that it is
                 // a part of the value
-                return (!characterParser.isPunctuator(str[x]) || quoteRe.test(str[x])) && self.assertExpression(val, true);
+                return (!characterParser.isPunctuator(str[x]) || quoteRe.test(str[x]) || str[x] === ':') && self.assertExpression(val, true);
               }
             }
           }

--- a/packages/pug/test/cases/attrs.colon.html
+++ b/packages/pug/test/cases/attrs.colon.html
@@ -1,0 +1,1 @@
+<div :my-var="model"></div><span v-for="item in items" :key="item.id" :value="item.name"></span><span v-for="item in items" :key="item.id" :value="item.name"></span><a :link="goHere" value="static" :my-value="dynamic" @click="onClick()" :another="more">Click Me!</a>

--- a/packages/pug/test/cases/attrs.colon.pug
+++ b/packages/pug/test/cases/attrs.colon.pug
@@ -1,0 +1,9 @@
+//- Tests for using a colon-prefexed attribute (typical when using short-cut for Vue.js `v-bind`)
+div(:my-var="model")
+span(v-for="item in items" :key="item.id" :value="item.name")
+span(
+  v-for="item in items"
+  :key="item.id"
+  :value="item.name"
+)
+a(:link="goHere" value="static" :my-value="dynamic" @click="onClick()" :another="more") Click Me!


### PR DESCRIPTION
* Add check for literal ‘:’
* Add test case for “typical” Vue.js short-cut syntax for `v-bind:`  (`:`)
* New test case passes with change (fails without the change)

Replaces #2713
Fixes #2454