### PR TITLE
Fixes #2774: "shadowed" blocks can be properly replaced / appended / prepended

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*   text=auto eol=lf

--- a/packages/pug-linker/index.js
+++ b/packages/pug-linker/index.js
@@ -76,9 +76,8 @@ function flattenParentBlocks(parentBlocks, accumulator) {
   parentBlocks.forEach(function (parentBlock) {
     if (parentBlock.parents) {
       flattenParentBlocks(parentBlock.parents, accumulator);
-    } else {
-      accumulator.push(parentBlock);
     }
+    accumulator.push(parentBlock);
   });
   return accumulator;
 }

--- a/packages/pug-linker/test/__snapshots__/index.test.js.snap
+++ b/packages/pug-linker/test/__snapshots__/index.test.js.snap
@@ -2412,6 +2412,74 @@ Object {
               Object {
                 "mustEscape": false,
                 "name": "class",
+                "val": "\'last\'",
+              },
+              Object {
+                "mustEscape": false,
+                "name": "class",
+                "val": "\'prepend\'",
+              },
+            ],
+            "block": Object {
+              "filename": "layout.multi.append.prepend.block.pug",
+              "line": 13,
+              "nodes": Array [
+                Object {
+                  "filename": "layout.multi.append.prepend.block.pug",
+                  "line": 13,
+                  "type": "Text",
+                  "val": "Last prepend must appear at top",
+                },
+              ],
+              "type": "Block",
+            },
+            "filename": "layout.multi.append.prepend.block.pug",
+            "isInline": false,
+            "line": 13,
+            "name": "p",
+            "selfClosing": false,
+            "type": "Tag",
+          },
+          Object {
+            "attributeBlocks": Array [],
+            "attrs": Array [
+              Object {
+                "mustEscape": false,
+                "name": "class",
+                "val": "\'first\'",
+              },
+              Object {
+                "mustEscape": false,
+                "name": "class",
+                "val": "\'prepend\'",
+              },
+            ],
+            "block": Object {
+              "filename": "layout.multi.append.prepend.block.pug",
+              "line": 7,
+              "nodes": Array [
+                Object {
+                  "filename": "layout.multi.append.prepend.block.pug",
+                  "line": 7,
+                  "type": "Text",
+                  "val": "Something prepended to content",
+                },
+              ],
+              "type": "Block",
+            },
+            "filename": "layout.multi.append.prepend.block.pug",
+            "isInline": false,
+            "line": 7,
+            "name": "p",
+            "selfClosing": false,
+            "type": "Tag",
+          },
+          Object {
+            "attributeBlocks": Array [],
+            "attrs": Array [
+              Object {
+                "mustEscape": false,
+                "name": "class",
                 "val": "\'content\'",
               },
             ],
@@ -2432,6 +2500,74 @@ Object {
             "isInline": false,
             "line": 4,
             "name": "div",
+            "selfClosing": false,
+            "type": "Tag",
+          },
+          Object {
+            "attributeBlocks": Array [],
+            "attrs": Array [
+              Object {
+                "mustEscape": false,
+                "name": "class",
+                "val": "\'first\'",
+              },
+              Object {
+                "mustEscape": false,
+                "name": "class",
+                "val": "\'append\'",
+              },
+            ],
+            "block": Object {
+              "filename": "layout.multi.append.prepend.block.pug",
+              "line": 4,
+              "nodes": Array [
+                Object {
+                  "filename": "layout.multi.append.prepend.block.pug",
+                  "line": 4,
+                  "type": "Text",
+                  "val": "Something appended to content",
+                },
+              ],
+              "type": "Block",
+            },
+            "filename": "layout.multi.append.prepend.block.pug",
+            "isInline": false,
+            "line": 4,
+            "name": "p",
+            "selfClosing": false,
+            "type": "Tag",
+          },
+          Object {
+            "attributeBlocks": Array [],
+            "attrs": Array [
+              Object {
+                "mustEscape": false,
+                "name": "class",
+                "val": "\'last\'",
+              },
+              Object {
+                "mustEscape": false,
+                "name": "class",
+                "val": "\'append\'",
+              },
+            ],
+            "block": Object {
+              "filename": "layout.multi.append.prepend.block.pug",
+              "line": 10,
+              "nodes": Array [
+                Object {
+                  "filename": "layout.multi.append.prepend.block.pug",
+                  "line": 10,
+                  "type": "Text",
+                  "val": "Last append must be most last",
+                },
+              ],
+              "type": "Block",
+            },
+            "filename": "layout.multi.append.prepend.block.pug",
+            "isInline": false,
+            "line": 10,
+            "name": "p",
             "selfClosing": false,
             "type": "Tag",
           },

--- a/packages/pug/test/shadowed-block/__snapshots__/index.test.js.snap
+++ b/packages/pug/test/shadowed-block/__snapshots__/index.test.js.snap
@@ -1,0 +1,3 @@
+exports[`test layout with shadowed block 1`] = `"<!-- layout.pug: root--><!-- index.pug: shadowed-->"`;
+
+exports[`test layout with shadowed block 2`] = `"<!-- layout.pug: root--><!-- index.pug: shadowed-->"`;

--- a/packages/pug/test/shadowed-block/base.pug
+++ b/packages/pug/test/shadowed-block/base.pug
@@ -1,0 +1,4 @@
+block root
+  // base.pug: root
+  block shadowed
+    // base.pug: shadowed

--- a/packages/pug/test/shadowed-block/index.pug
+++ b/packages/pug/test/shadowed-block/index.pug
@@ -1,0 +1,4 @@
+extends ./layout.pug
+
+block shadowed
+  // index.pug: shadowed

--- a/packages/pug/test/shadowed-block/index.test.js
+++ b/packages/pug/test/shadowed-block/index.test.js
@@ -1,0 +1,14 @@
+const pug = require('../../');
+
+test('layout with shadowed block', () => {
+  const outputWithAjax = pug.renderFile(
+    __dirname + '/index.pug',
+    {ajax: true}
+  );
+  const outputWithoutAjax = pug.renderFile(
+    __dirname + '/index.pug',
+    {ajax: false}
+  );
+  expect(outputWithAjax).toMatchSnapshot();
+  expect(outputWithoutAjax).toMatchSnapshot();
+});

--- a/packages/pug/test/shadowed-block/layout.pug
+++ b/packages/pug/test/shadowed-block/layout.pug
@@ -1,0 +1,6 @@
+extends ./base.pug
+
+block root
+  // layout.pug: root
+  block shadowed
+    // layout.pug: shadowed


### PR DESCRIPTION
Fixes #2774.