### PR TITLE
unsupported keyword for production environments

### DIFF
--- a/packages/pug-parser/index.js
+++ b/packages/pug-parser/index.js
@@ -388,7 +388,7 @@ loop:
   parseBlockExpansion: function(){
     var tok = this.accept(':');
     if (tok) {
-      const expr = this.parseExpr();
+      var expr = this.parseExpr();
       return expr.type === 'Block' ? expr : this.initBlock(tok.line, [expr]);
     } else {
       return this.block();


### PR DESCRIPTION
the "const" keyword is not supported in strict mode. ex. when the packages are downloaded on a remote machine with ~0.12 node version an error is thrown