### PR TITLE
replace const with var for use with 'strict'

### DIFF
--- a/packages/pug-parser/index.js
+++ b/packages/pug-parser/index.js
@@ -388,7 +388,7 @@ loop:
   parseBlockExpansion: function(){
     var tok = this.accept(':');
     if (tok) {
-      const expr = this.parseExpr();
+      var expr = this.parseExpr();
       return expr.type === 'Block' ? expr : this.initBlock(tok.line, [expr]);
     } else {
       return this.block();
@@ -1055,7 +1055,7 @@ loop:
         break;
       case ':':
         this.advance();
-        const expr = this.parseExpr();
+        var expr = this.parseExpr();
         tag.block = expr.type === 'Block' ? expr : this.initBlock(tag.line, [expr]);
         break;
       case 'newline':


### PR DESCRIPTION
Some applications with older node fails due to strict not allowing 'const' or 'let' keywords.