### PR TITLE
Remove duplicate uglify-js dependency from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,8 +66,7 @@
     "should": "*",
     "stop": "^3.0.0-rc1",
     "stylus": "*",
-    "twbs": "0.0.6",
-    "uglify-js": "*"
+    "twbs": "0.0.6"
   },
   "component": {
     "scripts": {


### PR DESCRIPTION
`uglify-js` is declared both as runtime and development dependency

This makes my install using `yarn install --production` to skip `uglify-js` from final bundle

This is actual for `jade@1.11.0`, `yarn@0.24.5` with `node@8.1.2`

