### PR TITLE
Add Node.js v8 to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - "4"
   - "6"
+  - "8"
 
 # Use faster Docker architecture on Travis.
 sudo: false


### PR DESCRIPTION
Add support for Node.js v8.
Updated .travis.yml.