### PR TITLE
Keep newline between text and interpolated-code

### DIFF
--- a/packages/pug-parser/index.js
+++ b/packages/pug-parser/index.js
@@ -304,7 +304,8 @@ Parser.prototype = {
           case 'newline':
             if (!options || !options.block) break loop;
             var tok = this.advance();
-            if (this.peek().type === 'text') {
+            var nextType = this.peek().type;
+            if (nextType === 'text' || nextType === 'interpolated-code') {
               tags.push({
                 type: 'Text',
                 val: '\n',

--- a/packages/pug-parser/test/__snapshots__/index.test.js.snap
+++ b/packages/pug-parser/test/__snapshots__/index.test.js.snap
@@ -16235,6 +16235,28 @@ Object {
       "type": "Text",
       "val": ".",
     },
+    Object {
+      "filename": "text.tokens.json",
+      "line": 45,
+      "type": "Text",
+      "val": "foo",
+    },
+    Object {
+      "filename": "text.tokens.json",
+      "line": 46,
+      "type": "Text",
+      "val": "
+",
+    },
+    Object {
+      "buffer": true,
+      "filename": "text.tokens.json",
+      "isInline": true,
+      "line": 46,
+      "mustEscape": true,
+      "type": "Code",
+      "val": "bar",
+    },
   ],
   "type": "Block",
 }

--- a/packages/pug-parser/test/cases/text.tokens.json
+++ b/packages/pug-parser/test/cases/text.tokens.json
@@ -84,4 +84,8 @@
 {"type":"newline","line":44,"col":1}
 {"type":"text","line":44,"col":3,"val":"."}
 {"type":"end-pipeless-text","line":44,"col":4}
-{"type":"eos","line":44,"col":4}
+{"type":"newline","line":45,"col": 1}
+{"type":"text","line":45,"col": 3,"val":"foo"}
+{"type":"newline","line":46,"col": 1}
+{"type":"interpolated-code","line":46,"col":3,"val":"bar","mustEscape":true,"buffer":true}
+{"type":"eos","line":46,"col":9}


### PR DESCRIPTION
Here, the following example will have a newline between `foo` and `bar`.
```pug
| foo
| bar
```

However, the following will not.
```pug
| foo
| #{bar}
```

This pull request fixes the behavior.

# Question
Should it also keep newline between text and code? For example,
```pug
| foo
= bar
```

This still won't have a newline.