### PR TITLE
Fix issue 2892: Online demo link in README is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Full documentation is at [pugjs.org](https://pugjs.org/)
  feature requests and questions, [open an issue](https://github.com/pugjs/pug/issues/new).
  For discussion join the [chat room](https://gitter.im/pugjs/pug).
 
- You can test drive Pug online [here](https://pugjs.org/).
+ You can test drive Pug online [here](https://pugjs.org/api/reference.html).
 
  [![Build Status](https://img.shields.io/travis/pugjs/pug/master.svg?style=flat)](https://travis-ci.org/pugjs/pug)
  [![Coverage Status](https://img.shields.io/coveralls/pugjs/pug/master.svg?style=flat)](https://coveralls.io/r/pugjs/pug?branch=master)


### PR DESCRIPTION
Fixes https://github.com/pugjs/pug/issues/2892

The new link target, https://pugjs.org/api/reference.html , says

> ::: float info Tip Pug is available in your Web browser's console! To test drive Pug's API, as documented on this page, try entering:
> 
> pug.render('p Hello world!');
> :::