### PR TITLE
Function "compileBody" exported for external use

### DIFF
--- a/packages/pug/lib/index.js
+++ b/packages/pug/lib/index.js
@@ -192,6 +192,7 @@ function compileBody(str, options){
 
   return {body: js, dependencies: dependencies};
 }
+exports.compileBody = compileBody;
 
 /**
  * Get the template from a string or a file, either compiled on-the-fly or


### PR DESCRIPTION
I wanted to prepare compiled functions for exchanging between my applications: one app compiles the 'pug' function (a prepared string of function, when using "compileBody"), the other receives a it and builds the function. ('pug' files of my projects are stored on server "1", but web-server is the server "2").