### PR TITLE
Fix #2911

### DIFF
--- a/packages/pug-code-gen/index.js
+++ b/packages/pug-code-gen/index.js
@@ -147,7 +147,7 @@ Compiler.prototype = {
         ');' +
         '}';
     }
-    return buildRuntime(this.runtimeFunctionsUsed) + 'function ' + (this.options.templateName || 'template') + '(locals) {var pug_html = "", pug_mixins = {}, pug_interp;' + js + ';return pug_html;}';
+    return buildRuntime(this.runtimeFunctionsUsed) + ';function ' + (this.options.templateName || 'template') + '(locals) {var pug_html = "", pug_mixins = {}, pug_interp;' + js + ';return pug_html;}';
   },
 
   /**


### PR DESCRIPTION
Fix for #2911 

Minifications can lead to invalid syntax. To be safe, adding this extra semi-colon will ensure that `buildRuntime(this.runttimeFunctionsUsed)` wouldn't cause `function template()` to be at wrong place, when generated by [code-gen](https://github.com/bogas04/pug/blob/f8d86d8670faa5b69ba286c835f8e9c231bdeb4f/packages/pug-code-gen/index.js#L147-L150), such as [this](https://gist.github.com/bogas04/7760c576584ea78517b55aeb17c40864) one.


```js
function () {
  return function pug_rethrow(){/* some awesome stuff */}function template(){/* more awesome stuff */}
}
// -----------------------------------------------------^
// Unexpected token function
// Adding `;` or `\n` fixes it
```