### PR TITLE
fix to allow locals.locals to work!

### DIFF
--- a/packages/pug-code-gen/index.js
+++ b/packages/pug-code-gen/index.js
@@ -661,6 +661,12 @@ Compiler.prototype = {
     // Buffer code
     if (code.buffer) {
       var val = code.val.trim();
+
+      //allow references to locals.locals
+      if (!this.options.self && val.startsWith('locals.')) {
+        val = 'locals.'+val;
+      }
+
       val = 'null == (pug_interp = '+val+') ? "" : pug_interp';
       if (code.mustEscape !== false) val = this.runtime('escape') + '(' + val + ')';
       this.bufferExpression(val);


### PR DESCRIPTION
issue here:
https://github.com/pugjs/pug/issues/2914

basically if i want to have a template "namespace" called "locals", it is impossible because the code-gen does not take into account this scenario. The following line of code in _pug-code-gen/index.js_ `compile()`:

```js = addWith('locals || {}', js, globals.concat(this.runtimeFunctionsUsed.map(function (name) { return 'pug_' + name; })));``` 

...this causes the `addWith()` call to skip injecting "locals" into the generated closure. It is then assuming access to `locals.*` using the parent closure, the original locals passed to the `template(locals)` function. The result is that the generated template is looking for `locals.foo` when it should be looking for `locals.locals.foo`.

So my fix basically adds the ying to this yang. No idea what this may break elsewhere?