### PR TITLE
[pug-lexer] Relax class name requirements

### DIFF
--- a/packages/pug-lexer/index.js
+++ b/packages/pug-lexer/index.js
@@ -403,20 +403,17 @@ Lexer.prototype = {
    */
 
   className: function() {
-    var tok = this.scan(/^\.(-?-?[_a-z][_a-z0-9\-]*)/i, 'class');
+    var tok = this.scan(/^\.([_a-z0-9\-]*[_a-z][_a-z0-9\-]*)/i, 'class');
     if (tok) {
       this.tokens.push(tok);
       this.incrementColumn(tok.val.length);
       return true;
     }
-    if (/^\.\-/i.test(this.input)) {
-      this.error('INVALID_CLASS_NAME', 'If a class name begins with a "-" or "--", it must be followed by a letter or underscore.');
-    }
-    if (/^\.[0-9]/i.test(this.input)) {
-      this.error('INVALID_CLASS_NAME', 'Class names must begin with "-", "_" or a letter.');
+    if (/^\.[_a-z0-9\-]+/i.test(this.input)) {
+      this.error('INVALID_CLASS_NAME', 'Class names must contain at least one letter or underscore.');
     }
     if (/^\./.test(this.input)) {
-      this.error('INVALID_CLASS_NAME', '"' + /.[^ \t\(\#\.\:]*/.exec(this.input.substr(1))[0] + '" is not a valid class name.  Class names must begin with "-", "_" or a letter and can only contain "_", "-", a-z and 0-9.');
+      this.error('INVALID_CLASS_NAME', '"' + /.[^ \t\(\#\.\:]*/.exec(this.input.substr(1))[0] + '" is not a valid class name.  Class names can only contain "_", "-", a-z and 0-9, and must contain at least one of "_", or a-z');
     }
   },
 

--- a/packages/pug-lexer/test/__snapshots__/index.test.js.snap
+++ b/packages/pug-lexer/test/__snapshots__/index.test.js.snap
@@ -3464,12 +3464,46 @@ Array [
   },
   Object {
     "col": 1,
-    "line": 12,
+    "line": 13,
     "type": "newline",
   },
   Object {
     "col": 1,
-    "line": 12,
+    "line": 13,
+    "type": "tag",
+    "val": "a",
+  },
+  Object {
+    "col": 2,
+    "line": 13,
+    "type": "class",
+    "val": "-foo",
+  },
+  Object {
+    "col": 1,
+    "line": 14,
+    "type": "newline",
+  },
+  Object {
+    "col": 1,
+    "line": 14,
+    "type": "tag",
+    "val": "a",
+  },
+  Object {
+    "col": 2,
+    "line": 14,
+    "type": "class",
+    "val": "3foo",
+  },
+  Object {
+    "col": 1,
+    "line": 15,
+    "type": "newline",
+  },
+  Object {
+    "col": 1,
+    "line": 15,
     "type": "eos",
   },
 ]
@@ -10689,7 +10723,7 @@ Object {
   "code": "PUG:INVALID_CLASS_NAME",
   "column": 1,
   "line": 1,
-  "msg": "Class names must begin with \"-\", \"_\" or a letter.",
+  "msg": "Class names must contain at least one letter or underscore.",
 }
 `;
 
@@ -10698,7 +10732,7 @@ Object {
   "code": "PUG:INVALID_CLASS_NAME",
   "column": 1,
   "line": 1,
-  "msg": "If a class name begins with a \"-\" or \"--\", it must be followed by a letter or underscore.",
+  "msg": "Class names must contain at least one letter or underscore.",
 }
 `;
 
@@ -10707,7 +10741,7 @@ Object {
   "code": "PUG:INVALID_CLASS_NAME",
   "column": 1,
   "line": 1,
-  "msg": "\"ä\" is not a valid class name.  Class names must begin with \"-\", \"_\" or a letter and can only contain \"_\", \"-\", a-z and 0-9.",
+  "msg": "\"ä\" is not a valid class name.  Class names can only contain \"_\", \"-\", a-z and 0-9, and must contain at least one of \"_\", or a-z",
 }
 `;
 

--- a/packages/pug-lexer/test/cases/classes.pug
+++ b/packages/pug-lexer/test/cases/classes.pug
@@ -9,3 +9,6 @@ a.foo(class='bar').baz
 a.foo-bar_baz
 
 a(class={foo: true, bar: false, baz: true})
+
+a.-foo
+a.3foo


### PR DESCRIPTION
* Allow class names to begin with single dash, 0-9, a-z, and underscore
* Add test case that passes with change, fails without change

Fixes #2907