### PR TITLE
Ignore *lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ npm-debug.log
 **/test/temp
 .release.json
 lerna-debug.log
+package-lock.json


### PR DESCRIPTION
After installing dependencies (npm@5.5.1) it automatically adds 'package-lock.json' file to each sub-project. I guess that we don't have lockfiles intentionally, so I asked git to ignore such files.

If that is not what we want, let's track lockfiles in git.