### PR TITLE
pug-codegen: Abstract parts of the code generator that accumulate output

### DIFF
--- a/packages/pug-attrs/index.js
+++ b/packages/pug-attrs/index.js
@@ -61,8 +61,15 @@ function compileAttrs(attrs, options) {
         buf.push(stringify(key) + ': ' + stringify(val));
       }
     } else {
+      var filter =
+          options.bufferHooks
+          ? options.bufferHooks.attrFilter(key)
+          : null;
+      if (filter) {
+        val = options.runtime(filter) + '(' + val + ')';
+      }
       if (options.format === 'html') {
-        buf.push(options.runtime('attr') + '("' + key + '", ' + val + ', ' + stringify(mustEscape) + ', ' + stringify(options.terse) + ')');
+        buf.push(options.runtime('attr') + '(' + stringify(key) + ', ' + val + ', ' + stringify(mustEscape) + ', ' + stringify(options.terse) + ')');
       } else {
         if (mustEscape) {
           val = options.runtime('escape') + '(' + val + ')';

--- a/packages/pug/lib/index.js
+++ b/packages/pug/lib/index.js
@@ -181,7 +181,8 @@ function compileBody(str, options){
     globals: options.globals,
     self: options.self,
     includeSources: options.includeSources ? debug_sources : false,
-    templateName: options.templateName
+    templateName: options.templateName,
+    bufferHooks: options.bufferHooks
   });
   js = applyPlugins(js, options, plugins, 'postCodeGen');
 
@@ -256,6 +257,7 @@ exports.compile = function(str, options){
     filterOptions: options.filterOptions,
     filterAliases: options.filterAliases,
     plugins: options.plugins,
+    bufferHooks: options.bufferHooks
   });
 
   var res = options.inlineRuntimeFunctions
@@ -303,7 +305,8 @@ exports.compileClientWithDependenciesTracked = function(str, options){
     filters: options.filters,
     filterOptions: options.filterOptions,
     filterAliases: options.filterAliases,
-    plugins: options.plugins
+    plugins: options.plugins,
+    bufferHooks: options.bufferHooks
   });
 
   var body = parsed.body;

--- a/packages/pug/test/__snapshots__/pug.test.js.snap
+++ b/packages/pug/test/__snapshots__/pug.test.js.snap
@@ -74,11 +74,9 @@ function pug_rethrow(n, e, r, t) {
         return (t == r ? \"  > \" : \"    \") + t + \"| \" + n;
       })
       .join(\"\\n\");
-  throw (
-    (n.path = e),
-    (n.message = (e || \"Pug\") + \":\" + r + \"\\n\" + i + \"\\n\\n\" + n.message),
-    n
-  );
+  throw ((n.path = e),
+  (n.message = (e || \"Pug\") + \":\" + r + \"\\n\" + i + \"\\n\\n\" + n.message),
+  n);
 }
 function template(locals) {
   var pug_html = \"\",


### PR DESCRIPTION
This consolidates code generator code that produces instructions to
append content to the output and allows customizing it.

This enables features like https://github.com/pugjs/pug/pull/2895
which distinguishes between strings definitely authored by the
template author and those possibly controlled by an attacker to escape
strings in context.

This approach allows the same hooks to both handle idiomatic pug like

```pug
a[href=x]
```

and inlne html like

```html
<a href="#{x}"></a>
```

See also https://github.com/pugjs/pug/issues/2952