### PR TITLE
Ignore yarn.lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ npm-debug.log
 .release.json
 lerna-debug.log
 package-lock.json
+yarn.lock


### PR DESCRIPTION
This is continuation of https://github.com/pugjs/pug/pull/2955: adds yarn.lock file to .gitignore.