### PR TITLE
Add possibility to pass custom options to plugins

### DIFF
--- a/packages/pug/lib/index.js
+++ b/packages/pug/lib/index.js
@@ -255,6 +255,7 @@ exports.compile = function(str, options){
     filterOptions: options.filterOptions,
     filterAliases: options.filterAliases,
     plugins: options.plugins,
+    pluginOptions: options.pluginOptions
   });
 
   var res = options.inlineRuntimeFunctions
@@ -302,7 +303,8 @@ exports.compileClientWithDependenciesTracked = function(str, options){
     filters: options.filters,
     filterOptions: options.filterOptions,
     filterAliases: options.filterAliases,
-    plugins: options.plugins
+    plugins: options.plugins,
+    pluginOptions: options.pluginOptions
   });
 
   var body = parsed.body;

--- a/packages/pug/test/plugin-options.test.js
+++ b/packages/pug/test/plugin-options.test.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var pug = require('../');
+var pugLoad = require('../../pug-load');
+var assert = require('assert');
+var fs = require('fs');
+
+describe('plugin options', function () {
+  it('should list the filename of the template referenced by extends', function(){
+    var filename = __dirname + '/dependencies/extends1.pug';
+    var str = fs.readFileSync(filename, 'utf8');
+    var pugLoadPlugin = {
+      resolve: (filename, source, options) => {
+        assert(options.pluginOptions !== undefined);
+        assert(options.pluginOptions.test === 'something');
+        return pugLoad.resolve(filename, source, options);
+      }
+    }
+    const options = {
+      plugins: [
+        pugLoadPlugin
+      ],
+      filename: filename,
+      pluginOptions: {
+        test: 'something'
+      }
+    };
+
+    pug.compile(str, options);
+  });
+});


### PR DESCRIPTION
Currently only certain options are passed to `compileBody` and therefore it is not possible pass custom options to plugins.

This adds a possibly to pass custom options to plugins by adding a property named `pluginOptions` to the options that are passed to `compileOptions`.