### PR TITLE
Closes #2988 "Update clean-css dependency in pug-filters"

### DIFF
--- a/packages/pug-filters/package.json
+++ b/packages/pug-filters/package.json
@@ -6,7 +6,7 @@
     "pug"
   ],
   "dependencies": {
-    "clean-css": "^3.3.0",
+    "clean-css": "^4.1.11",
     "constantinople": "^3.0.1",
     "jstransformer": "1.0.0",
     "pug-error": "^1.3.2",


### PR DESCRIPTION
This is my first pull request (on a forked public repo at least), so please let me know if I'm missing anything.

None of the breaking changes in clean-css v4 should affect you, assuming this line in **run-filter.js** is the only place where you use it:

`result = new CleanCSS().minify(result).styles;`

This will close #2988.