### PR TITLE
[pug-filters] Throw error if error when attempting to require filter

### DIFF
--- a/packages/pug-filters/lib/run-filter.js
+++ b/packages/pug-filters/lib/run-filter.js
@@ -8,38 +8,34 @@ var resolve = require('resolve');
 module.exports = filter;
 function filter(name, str, options, currentDirectory, funcName) {
   funcName = funcName || 'render';
-  var tr;
+  var trPath;
   try {
     try {
-      tr = require(resolve.sync('jstransformer-' + name, {basedir: currentDirectory || process.cwd()}));
+      trPath = resolve.sync('jstransformer-' + name, {basedir: currentDirectory || process.cwd()});
     } catch (ex) {
-      tr = require('jstransformer-' + name);
+      trPath = require.resolve('jstransformer-' + name);
     }
-    tr = jstransformer(tr);
   } catch (ex) {
-    throw ex;
-  }
-  if (tr) {
-    // TODO: we may want to add a way for people to separately specify "locals"
-    var result = tr[funcName](str, options, options).body;
-    if (options && options.minify) {
-      try {
-        switch (tr.outputFormat) {
-          case 'js':
-            result = uglify.minify(result, {fromString: true}).code;
-            break;
-          case 'css':
-            result = new CleanCSS().minify(result).styles;
-            break;
-        }
-      } catch (ex) {
-        // better to fail to minify than output nothing
-      }
-    }
-    return result;
-  } else {
     var err = new Error('unknown filter ":' + name + '"');
     err.code = 'UNKNOWN_FILTER';
     throw err;
   }
+  var tr = jstransformer(require(trPath));
+  // TODO: we may want to add a way for people to separately specify "locals"
+  var result = tr[funcName](str, options, options).body;
+  if (options && options.minify) {
+    try {
+      switch (tr.outputFormat) {
+        case 'js':
+          result = uglify.minify(result, {fromString: true}).code;
+          break;
+        case 'css':
+          result = new CleanCSS().minify(result).styles;
+          break;
+      }
+    } catch (ex) {
+      // better to fail to minify than output nothing
+    }
+  }
+  return result;
 }


### PR DESCRIPTION
When an error is encountered in a `jstransformer` package that is being auto-imported, currently the exception is silently caught so that its hard to debug. For example

```javascript
// node_modules/jstransformer-hello-error/index.js

throw new Error('Oh no')

exports.render = () => {
  ...
}

// my-pug-template
.div
  :hello-error() 
```
Returns "cannot find `:hello-error` filter" rather than the exception being thrown somewhere in the source code. 
