### PR TITLE
[pug-runtime] toJSON method should be called on object-like values only. Fixes #2925

### DIFF
--- a/packages/pug-runtime/index.js
+++ b/packages/pug-runtime/index.js
@@ -132,7 +132,8 @@ function pug_attr(key, val, escaped, terse) {
   if (val === true) {
     return ' ' + (terse ? key : key + '="' + key + '"');
   }
-  if (typeof val.toJSON === 'function') {
+  var type = typeof val;
+  if ((type === 'object' || type === 'function') && typeof val.toJSON === 'function') {
     val = val.toJSON();
   }
   if (typeof val !== 'string') {

--- a/packages/pug-runtime/test/index.test.js
+++ b/packages/pug-runtime/test/index.test.js
@@ -14,6 +14,12 @@ function addTest(name, fn) {
 }
 
 addTest('attr', function (attr) { // (key, val, escaped, terse)
+  var stringToJSON = String.prototype.toJSON;
+
+  String.prototype.toJSON = function() {
+    return JSON.stringify(this);
+  };
+
   // Boolean Attributes
   expect(attr('key', true, true, true)).toBe(' key');
   expect(attr('key', true, false, true)).toBe(' key');
@@ -63,6 +69,8 @@ addTest('attr', function (attr) { // (key, val, escaped, terse)
   expect(attr('key', 'foo>bar', false, true)).toBe(' key="foo>bar"');
   expect(attr('key', 'foo>bar', true, false)).toBe(' key="foo&gt;bar"');
   expect(attr('key', 'foo>bar', false, false)).toBe(' key="foo>bar"');
+
+  String.prototype.toJSON = stringToJSON;
 });
 
 addTest('attrs', function (attrs) { // (obj, terse)


### PR DESCRIPTION
Overriding built-in method for `String` objects in test file turns `foo="boo"` result string into `foo="\"bar\""`.
Other primitive types are not so vulnerable to this so `String` prototype only is mangled.