### PR TITLE
pug_attr should preserve value token boundaries even when escaped=false

### DIFF
--- a/packages/pug-runtime/index.js
+++ b/packages/pug-runtime/index.js
@@ -142,7 +142,11 @@ function pug_attr(key, val, escaped, terse) {
       return ' ' + key + '=\'' + val.replace(/'/g, '&#39;') + '\'';
     }
   }
-  if (escaped) val = pug_escape(val);
+  if (escaped) {
+    val = pug_escape(val);
+  } else {
+    val = val.replace(/"/g, '&#34;');
+  }
   return ' ' + key + '="' + val + '"';
 };
 


### PR DESCRIPTION
# Before

```sh
$ node
> const pug_attr = require('pug-runtime').attr;
undefined
> pug_attr('name', 'val">', false)
' name="val">"'
```

# After

```sh
$ node
> const pug_attr = require('pug-runtime').attr;
undefined
> pug_attr('name', 'val">', false)
' name="val&#34;>"'
```