### PR TITLE
mark options as optional parameter (jsdoc fix)

### DIFF
--- a/packages/pug/lib/index.js
+++ b/packages/pug/lib/index.js
@@ -346,7 +346,7 @@ exports.compileClient = function (str, options) {
        the compiled template for better accuracy.
  *
  * @param {String} path
- * @param {Options} options
+ * @param {Options} [options]
  * @return {Function}
  * @api public
  */


### PR DESCRIPTION
Fix IDE warning about invalid number of arguments:

![image](https://user-images.githubusercontent.com/2598671/49012764-71fdb280-f18b-11e8-8811-db42f4545e84.png)
