### PR TITLE
Consume all whitespace and commas before the key

### DIFF
--- a/packages/pug-lexer/index.js
+++ b/packages/pug-lexer/index.js
@@ -1062,9 +1062,9 @@ Lexer.prototype = {
     var key = '';
     var i;
     
-    // consume all whitespace before the key
+    // consume all whitespace and commas before the key
     for(i = 0; i < str.length; i++){
-      if(!this.whitespaceRe.test(str[i])) break;
+      if(!(this.whitespaceRe.test(str[i]) || str[i] === ',')) break;
       if(str[i] === '\n'){
         this.incrementLine(1);
       } else {


### PR DESCRIPTION
This fix is essentially be a no-op. It lets `pug` be a little more lenient about commas in the attributes list. Right now, commas between attributes are optional and essentially just ignored. This small patch lets you begin a list of attributes with a comma or put several in the list, without giving any complaints. It just happily skips over them as if they were whitespace.

**Why is this PR requested?**

Because OCD makes me itch when I see these attributes not line up:

<img width="437" alt="untitled 2019-01-25 09-29-57" src="https://user-images.githubusercontent.com/142875/51758823-dfdb3300-2083-11e9-9718-544245c4e3ec.png">

To line up the code, we've been using this:

![image](https://user-images.githubusercontent.com/142875/51759162-da321d00-2084-11e9-925e-5777c15f7447.png)

But this is a little awkward too...

So, this PR allows valid `pug` (ie - a comma between attributes) to be used:

<img width="351" alt="untitled 2019-01-25 09-39-51" src="https://user-images.githubusercontent.com/142875/51759400-5fb5cd00-2085-11e9-9847-9087a9f55a82.png">

Maybe this is also a little weird... but, the PR allows these extra commas to be happily ignored.