### PR TITLE
Add support for custom view cache key

### DIFF
--- a/packages/pug/lib/index.js
+++ b/packages/pug/lib/index.js
@@ -207,7 +207,7 @@ function compileBody(str, options){
  * @api private
  */
 function handleTemplateCache (options, str) {
-  var key = options.filename;
+  var key = options.cacheKey || options.filename;
   if (options.cache && exports.cache[key]) {
     return exports.cache[key];
   } else {


### PR DESCRIPTION
I've implemented similar solution in Express. See discussion in https://github.com/expressjs/express/issues/3869.

This should provide a simple solution to fix the following issues:
https://github.com/pugjs/pug/issues/2603
https://github.com/pugjs/pug/issues/1782

If this will be merged into Express, I'd be glad to implement tests for this PR if necessary. Please provide me a guidance where to add them. `pug` or `pug-filters`?