### PR TITLE
Improve compilation performance

### DIFF
--- a/packages/pug-lexer/index.js
+++ b/packages/pug-lexer/index.js
@@ -4,12 +4,13 @@ var assert = require('assert');
 var isExpression = require('is-expression');
 var characterParser = require('character-parser');
 var error = require('pug-error');
+var clone = require('rfdc')();
 
 module.exports = lex;
 module.exports.Lexer = Lexer;
 function lex(str, options) {
   var lexer = new Lexer(str, options);
-  return JSON.parse(JSON.stringify(lexer.getTokens()));
+  return clone(lexer.getTokens());
 }
 
 /**

--- a/packages/pug-lexer/package.json
+++ b/packages/pug-lexer/package.json
@@ -8,7 +8,8 @@
   "dependencies": {
     "character-parser": "^2.1.1",
     "is-expression": "^3.0.0",
-    "pug-error": "^1.3.2"
+    "pug-error": "^1.3.2",
+    "rfdc": "^1.1.2"
   },
   "devDependencies": {
     "acorn": "^3.0.4"

--- a/packages/pug-load/index.js
+++ b/packages/pug-load/index.js
@@ -4,12 +4,13 @@ var fs = require('fs');
 var path = require('path');
 var walk = require('pug-walk');
 var assign = require('object-assign');
+var clone = require('rfdc')();
 
 module.exports = load;
 function load(ast, options) {
   options = getOptions(options);
   // clone the ast
-  ast = JSON.parse(JSON.stringify(ast));
+  ast = clone(ast);
   return walk(ast, function (node) {
     if (node.str === undefined) {
       if (node.type === 'Include' || node.type === 'RawInclude' || node.type === 'Extends') {

--- a/packages/pug-load/package.json
+++ b/packages/pug-load/package.json
@@ -7,7 +7,8 @@
   ],
   "dependencies": {
     "object-assign": "^4.1.0",
-    "pug-walk": "^1.1.7"
+    "pug-walk": "^1.1.7",
+    "rfdc": "^1.1.2"
   },
   "devDependencies": {
     "pug-lexer": "^4.0.0",

--- a/packages/pug-parser/index.js
+++ b/packages/pug-parser/index.js
@@ -4,13 +4,14 @@ var assert = require('assert');
 var TokenStream = require('token-stream');
 var error = require('pug-error');
 var inlineTags = require('./lib/inline-tags');
+var clone = require('rfdc')();
 
 module.exports = parse;
 module.exports.Parser = Parser;
 function parse(tokens, options) {
   var parser = new Parser(tokens, options);
   var ast = parser.parse();
-  return JSON.parse(JSON.stringify(ast));
+  return clone(ast);
 };
 
 /**

--- a/packages/pug-parser/package.json
+++ b/packages/pug-parser/package.json
@@ -7,6 +7,7 @@
   ],
   "dependencies": {
     "pug-error": "^1.3.2",
+    "rfdc": "^1.1.2",
     "token-stream": "0.0.1"
   },
   "devDependencies": {

--- a/packages/pug-parser/test/__snapshots__/no-unnecessary-blocks.test.js.snap
+++ b/packages/pug-parser/test/__snapshots__/no-unnecessary-blocks.test.js.snap
@@ -1,21 +1,25 @@
 exports[`test no uncessessary blocks should be added 1`] = `
 Object {
+  "filename": undefined,
   "line": 0,
   "nodes": Array [
     Object {
       "attributeBlocks": Array [],
       "attrs": Array [],
       "block": Object {
+        "filename": undefined,
         "line": 2,
         "nodes": Array [
           Object {
             "column": 5,
+            "filename": undefined,
             "line": 3,
             "type": "Text",
             "val": "Hello",
           },
           Object {
             "column": 1,
+            "filename": undefined,
             "line": 4,
             "type": "Text",
             "val": "
@@ -23,6 +27,7 @@ Object {
           },
           Object {
             "column": 5,
+            "filename": undefined,
             "line": 4,
             "type": "Text",
             "val": "World",
@@ -31,6 +36,7 @@ Object {
         "type": "Block",
       },
       "column": 1,
+      "filename": undefined,
       "isInline": false,
       "line": 2,
       "name": "div",


### PR DESCRIPTION
This improves the compilation performance by replacing cloning with `JSON.parse(JSON.stringify(...))` with the [rfdc](https://github.com/davidmarkclements/rfdc) module.

Edit: I measured an improvement of 10 % to 15 % with this change on different template sizes.

