### PR TITLE
improve pug_escape performance

### DIFF
--- a/packages/pug-runtime/index.js
+++ b/packages/pug-runtime/index.js
@@ -184,16 +184,32 @@ function pug_attrs(obj, terse){
  * @api private
  */
 
-var pug_match_html = /["&<>]/;
 exports.escape = pug_escape;
 function pug_escape(_html){
   var html = '' + _html;
-  var regexResult = pug_match_html.exec(html);
-  if (!regexResult) return _html;
+  var escapeIndex = -1
+  var index1 = html.indexOf('"');
+  var index2 = html.indexOf('&');
+  var index3 = html.indexOf('<');
+  var index4 = html.indexOf('>');
+
+  if (index1 > -1) {
+    escapeIndex = index1
+  }
+  if (index2 > -1 && (index2 < escapeIndex || escapeIndex === -1)) {
+    escapeIndex = index2
+  }
+  if (index3 > -1 && (index3 < escapeIndex || escapeIndex === -1)) {
+    escapeIndex = index3
+  }
+  if (index4 > -1 && (index4 < escapeIndex || escapeIndex === -1)) {
+    escapeIndex = index4
+  }
+  if (escapeIndex === -1 ) return _html;
 
   var result = '';
   var i, lastIndex, escape;
-  for (i = regexResult.index, lastIndex = 0; i < html.length; i++) {
+  for (i = escapeIndex, lastIndex = 0; i < html.length; i++) {
     switch (html.charCodeAt(i)) {
       case 34: escape = '&quot;'; break;
       case 38: escape = '&amp;'; break;

--- a/packages/pug-runtime/index.js
+++ b/packages/pug-runtime/index.js
@@ -176,6 +176,18 @@ function pug_attrs(obj, terse){
   return attrs;
 };
 
+var pug_encode_html_rules = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;'
+};
+var pug_match_html = /[&<>"]/g;
+
+function pug_encode_char(c) {
+  return pug_encode_html_rules[c] || c;
+}
+
 /**
  * Escape the given string of `html`.
  *
@@ -183,7 +195,6 @@ function pug_attrs(obj, terse){
  * @return {String}
  * @api private
  */
-
 exports.escape = pug_escape;
 function pug_escape(_html){
   var html = '' + _html;
@@ -206,6 +217,10 @@ function pug_escape(_html){
     escapeIndex = index4
   }
   if (escapeIndex === -1 ) return _html;
+
+  if (escapeIndex < html.length / 2) {
+    return html.replace(pug_match_html, pug_encode_char);
+  }
 
   var result = '';
   var i, lastIndex, escape;

--- a/packages/pug/test/__snapshots__/pug.test.js.snap
+++ b/packages/pug/test/__snapshots__/pug.test.js.snap
@@ -24,27 +24,37 @@ module.exports = template;
 `;
 
 exports[`pug .compileClient() should support module syntax in pug.compileClient(str, options) when inlineRuntimeFunctions it true 1`] = `
-"function pug_escape(e) {
-  var a = \"\" + e,
-    r = -1,
-    n = a.indexOf('"'),
-    t = a.indexOf("&"),
-    i = a.indexOf("<"),
-    s = a.indexOf(">");
+"function pug_encode_char(e) {
+  return pug_encode_html_rules[e] || e;
+}
+var pug_encode_html_rules = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;"
+};
+function pug_escape(e) {
+  var r = "" + e,
+    a = -1,
+    t = r.indexOf('"'),
+    n = r.indexOf("&"),
+    c = r.indexOf("<"),
+    u = r.indexOf(">");
   if (
-    (n > -1 && (r = n),
-    t > -1 && (t < r || -1 === r) && (r = t),
-    i > -1 && (i < r || -1 === r) && (r = i),
-    s > -1 && (s < r || -1 === r) && (r = s),
-    -1 === r)
+    (t > -1 && (a = t),
+    n > -1 && (n < a || -1 === a) && (a = n),
+    c > -1 && (c < a || -1 === a) && (a = c),
+    u > -1 && (u < a || -1 === a) && (a = u),
+    -1 === a)
   )
     return e;
-  var c,
-    u,
+  if (a < r.length / 2) return r.replace(pug_match_html, pug_encode_char);
+  var i,
+    s,
     f,
-    b = "";
-  for (c = r, u = 0; c < a.length; c++) {
-    switch (a.charCodeAt(c)) {
+    g = "";
+  for (i = a, s = 0; i < r.length; i++) {
+    switch (r.charCodeAt(i)) {
       case 34:
         f = "&quot;";
         break;
@@ -60,10 +70,11 @@ exports[`pug .compileClient() should support module syntax in pug.compileClient(
       default:
         continue;
     }
-    u !== c && (b += a.substring(u, c)), (u = c + 1), (b += f);
+    s !== i && (g += r.substring(s, i)), (s = i + 1), (g += f);
   }
-  return u !== c ? b + a.substring(u, c) : b;
+  return s !== i ? g + r.substring(s, i) : g;
 }
+var pug_match_html = /[&<>"]/g;
 function pug_rethrow(n, e, r, t) {
   if (!(n instanceof Error)) throw n;
   if (!((\"undefined\" == typeof window && e) || t))

--- a/packages/pug/test/__snapshots__/pug.test.js.snap
+++ b/packages/pug/test/__snapshots__/pug.test.js.snap
@@ -26,34 +26,44 @@ module.exports = template;
 exports[`pug .compileClient() should support module syntax in pug.compileClient(str, options) when inlineRuntimeFunctions it true 1`] = `
 "function pug_escape(e) {
   var a = \"\" + e,
-    t = pug_match_html.exec(a);
-  if (!t) return e;
-  var r,
-    c,
-    n,
-    s = \"\";
-  for (r = t.index, c = 0; r < a.length; r++) {
-    switch (a.charCodeAt(r)) {
+    r = -1,
+    n = a.indexOf('"'),
+    t = a.indexOf("&"),
+    i = a.indexOf("<"),
+    s = a.indexOf(">");
+  if (
+    (n > -1 && (r = n),
+    t > -1 && (t < r || -1 === r) && (r = t),
+    i > -1 && (i < r || -1 === r) && (r = i),
+    s > -1 && (s < r || -1 === r) && (r = s),
+    -1 === r)
+  )
+    return e;
+  var c,
+    u,
+    f,
+    b = "";
+  for (c = r, u = 0; c < a.length; c++) {
+    switch (a.charCodeAt(c)) {
       case 34:
-        n = \"&quot;\";
+        f = "&quot;";
         break;
       case 38:
-        n = \"&amp;\";
+        f = "&amp;";
         break;
       case 60:
-        n = \"&lt;\";
+        f = "&lt;";
         break;
       case 62:
-        n = \"&gt;\";
+        f = "&gt;";
         break;
       default:
         continue;
     }
-    c !== r && (s += a.substring(c, r)), (c = r + 1), (s += n);
+    u !== c && (b += a.substring(u, c)), (u = c + 1), (b += f);
   }
-  return c !== r ? s + a.substring(c, r) : s;
+  return u !== c ? b + a.substring(u, c) : b;
 }
-var pug_match_html = /[\"&<>]/;
 function pug_rethrow(n, e, r, t) {
   if (!(n instanceof Error)) throw n;
   if (!((\"undefined\" == typeof window && e) || t))


### PR DESCRIPTION
This improves the performance of `pug_escape()` by replacing the Regular Expression that searches for chars that need to be escaped with calls to`indexOf()`.

I wrote a benchmark that tests the performance with strings containing chars that need to be escaped at different positions:

```
new - nothing to escape x 3,636,837 ops/sec ±0.42% (89 runs sampled)
old - nothing to escape x 1,186,265 ops/sec ±1.33% (91 runs sampled)
new - chars to escape - at end x 2,183,489 ops/sec ±0.63% (90 runs sampled)
old - chars to escape - at end x 851,802 ops/sec ±0.35% (93 runs sampled)
new - chars to escape - at middle x 303,275 ops/sec ±0.38% (91 runs sampled)
old - chars to escape - at middle x 246,988 ops/sec ±0.84% (89 runs sampled)
new - chars to escape - at start x 153,486 ops/sec ±0.70% (91 runs sampled)
old - chars to escape - at start x 138,075 ops/sec ±0.37% (90 runs sampled)
```

The code of the benchmark can be found here:
https://github.com/SerayaEryn/pug/blob/improve-pug_escape-performance-benchmark/packages/pug-runtime/pugEscapeBenchmark.js