### PR TITLE
Add keywords to pug package.json

### DIFF
--- a/packages/pug/package.json
+++ b/packages/pug/package.json
@@ -1,6 +1,12 @@
 {
   "name": "pug",
   "description": "A clean, whitespace-sensitive template language for writing HTML",
+  "keywords": [
+    "html",
+    "jade",
+    "pug",
+    "template"
+  ],
   "version": "2.0.3",
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "maintainers": [


### PR DESCRIPTION
I noticed that searching for "jade" on NPM does not show this module in the search results. It only shows up if you search via the exact name "pug".

This PR adds some keywords to the main module package.json to improve searchability. The order isn't meant to be a priority order. It's just sorted alphabetically to allow cleaner diffs in the future.