### PR TITLE
Fix the dependency status badges in README.md of the child packages"

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,28 @@ Full documentation is at [pugjs.org](https://pugjs.org/)
 
  [![Build Status](https://img.shields.io/travis/pugjs/pug/master.svg?style=flat)](https://travis-ci.org/pugjs/pug)
  [![Coverage Status](https://img.shields.io/coveralls/pugjs/pug/master.svg?style=flat)](https://coveralls.io/r/pugjs/pug?branch=master)
- [![Dependency Status](https://img.shields.io/david/pugjs/pug.svg?style=flat)](https://david-dm.org/pugjs/pug)
- [![devDependencies Status](https://img.shields.io/david/dev/pugjs/pug.svg?style=flat)](https://david-dm.org/pugjs/pug?type=dev)
  [![NPM version](https://img.shields.io/npm/v/pug.svg?style=flat)](https://www.npmjs.com/package/pug)
  [![Join Gitter Chat](https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg?style=flat)](https://gitter.im/pugjs/pug?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![OpenCollective](https://opencollective.com/pug/backers/badge.svg)](#backers) 
 [![OpenCollective](https://opencollective.com/pug/sponsors/badge.svg)](#sponsors)
+
+### Dependency Status
+
+| Package        | Dependencies           | Dev Dependencies  |
+| ------------- |:-------------| :-----|
+| mono-repo top      |  [![Dependency Status](https://img.shields.io/david/pugjs/pug.svg?style=flat)](https://david-dm.org/pugjs/pug) |  [![devDependencies Status](https://img.shields.io/david/dev/pugjs/pug.svg?style=flat)](https://david-dm.org/pugjs/pug?type=dev) |
+| pug | [![Dependencies Status](https://david-dm.org/pugjs/pug/status.svg?path=packages/pug)](https://david-dm.org/pugjs/pug?path=packages/pug)      |    [![Dependencies Status](https://david-dm.org/pugjs/pug/dev-status.svg?path=packages/pug)](https://david-dm.org/pugjs/pug?path=packages/pug&type=dev) |
+| pug-attrs      | [![Dependencies Status](https://david-dm.org/pugjs/pug/status.svg?path=packages/pug-attrs)](https://david-dm.org/pugjs/pug?path=packages/pug-attrs)      |   [![Dependencies Status](https://david-dm.org/pugjs/pug/dev-status.svg?path=packages/pug-attrs)](https://david-dm.org/pugjs/pug?path=packages/pug-attrs&type=dev) |
+| pug-code-gen | [![Dependencies Status](https://david-dm.org/pugjs/pug/status.svg?path=packages/pug-code-gen)](https://david-dm.org/pugjs/pug?path=packages/pug-code-gen)      |    [![Dependencies Status](https://david-dm.org/pugjs/pug/dev-status.svg?path=packages/pug-code-gen)](https://david-dm.org/pugjs/pug?path=packages/pug-code-gen&type=dev) |
+| pug-error | [![Dependencies Status](https://david-dm.org/pugjs/pug/status.svg?path=packages/pug-error)](https://david-dm.org/pugjs/pug?path=packages/pug-error)      |    [![Dependencies Status](https://david-dm.org/pugjs/pug/dev-status.svg?path=packages/pug-error)](https://david-dm.org/pugjs/pug?path=packages/pug-error&type=dev) |
+| pug-filters | [![Dependencies Status](https://david-dm.org/pugjs/pug/status.svg?path=packages/pug-filters)](https://david-dm.org/pugjs/pug?path=packages/pug-filters)      |    [![Dependencies Status](https://david-dm.org/pugjs/pug/dev-status.svg?path=packages/pug-filters)](https://david-dm.org/pugjs/pug?path=packages/pug-filters&type=dev) |
+| pug-lexer | [![Dependencies Status](https://david-dm.org/pugjs/pug/status.svg?path=packages/pug-lexer)](https://david-dm.org/pugjs/pug?path=packages/pug-lexer)      |    [![Dependencies Status](https://david-dm.org/pugjs/pug/dev-status.svg?path=packages/pug-lexer)](https://david-dm.org/pugjs/pug?path=packages/pug-lexer&type=dev) |
+| pug-linker | [![Dependencies Status](https://david-dm.org/pugjs/pug/status.svg?path=packages/pug-linker)](https://david-dm.org/pugjs/pug?path=packages/pug-linker)      |    [![Dependencies Status](https://david-dm.org/pugjs/pug/dev-status.svg?path=packages/pug-linker)](https://david-dm.org/pugjs/pug?path=packages/pug-linker&type=dev) |
+| pug-load | [![Dependencies Status](https://david-dm.org/pugjs/pug/status.svg?path=packages/pug-load)](https://david-dm.org/pugjs/pug?path=packages/pug-load)      |    [![Dependencies Status](https://david-dm.org/pugjs/pug/dev-status.svg?path=packages/pug-load)](https://david-dm.org/pugjs/pug?path=packages/pug-load&type=dev) |
+| pug-parser | [![Dependencies Status](https://david-dm.org/pugjs/pug/status.svg?path=packages/pug-parser)](https://david-dm.org/pugjs/pug?path=packages/pug-parser)      |    [![Dependencies Status](https://david-dm.org/pugjs/pug/dev-status.svg?path=packages/pug-parser)](https://david-dm.org/pugjs/pug?path=packages/pug-parser&type=dev) |
+| pug-runtime | [![Dependencies Status](https://david-dm.org/pugjs/pug/status.svg?path=packages/pug-runtime)](https://david-dm.org/pugjs/pug?path=packages/pug-runtime)      |    [![Dependencies Status](https://david-dm.org/pugjs/pug/dev-status.svg?path=packages/pug-runtime)](https://david-dm.org/pugjs/pug?path=packages/pug-runtime&type=dev) |
+| pug-strip-comments | [![Dependencies Status](https://david-dm.org/pugjs/pug/status.svg?path=packages/pug-strip-comments)](https://david-dm.org/pugjs/pug?path=packages/pug-strip-comments)      |    [![Dependencies Status](https://david-dm.org/pugjs/pug/dev-status.svg?path=packages/pug-strip-comments)](https://david-dm.org/pugjs/pug?path=packages/pug-strip-comments&type=dev) |
+| pug-error | [![Dependencies Status](https://david-dm.org/pugjs/pug/status.svg?path=packages/pug-walk)](https://david-dm.org/pugjs/pug?path=packages/pug-walk)      |    [![Dependencies Status](https://david-dm.org/pugjs/pug/dev-status.svg?path=packages/pug-walk)](https://david-dm.org/pugjs/pug?path=packages/pug-walk&type=dev) |
 
 ## Rename from "Jade"
 

--- a/packages/pug-attrs/README.md
+++ b/packages/pug-attrs/README.md
@@ -3,7 +3,7 @@
 Generate code for Pug attributes
 
 [![Build Status](https://img.shields.io/travis/pugjs/pug-attrs/master.svg)](https://travis-ci.org/pugjs/pug-attrs)
-[![Dependency Status](https://img.shields.io/david/pugjs/pug-attrs.svg)](https://david-dm.org/pugjs/pug-attrs)
+[![Dependencies Status](https://david-dm.org/pugjs/pug/status.svg?path=packages/pug-attrs)](https://david-dm.org/pugjs/pug?path=packages/pug-attrs)
 [![NPM version](https://img.shields.io/npm/v/pug-attrs.svg)](https://www.npmjs.org/package/pug-attrs)
 
 ## Installation

--- a/packages/pug-code-gen/README.md
+++ b/packages/pug-code-gen/README.md
@@ -3,7 +3,7 @@
 Default code-generator for pug.  It generates HTML via a JavaScript template function.
 
 <!-- [![Build Status](https://img.shields.io/travis/pugjs/pug-code-gen/master.svg)](https://travis-ci.org/pugjs/pug-code-gen) -->
-[![Dependency Status](https://img.shields.io/david/pugjs/pug-code-gen.svg)](https://david-dm.org/pugjs/pug-code-gen)
+[![Dependencies Status](https://david-dm.org/pugjs/pug/status.svg?path=packages/pug-code-gen)](https://david-dm.org/pugjs/pug?path=packages/pug-code-gen)
 [![npm version](https://img.shields.io/npm/v/pug-code-gen.svg)](https://www.npmjs.org/package/pug-code-gen)
 
 ## Installation

--- a/packages/pug-error/README.md
+++ b/packages/pug-error/README.md
@@ -3,7 +3,7 @@
 Standard error objects for pug.  This module is intended for use by the lexer, parser, loader, linker, code-generator and any plugins.
 
 [![Build Status](https://img.shields.io/travis/pugjs/pug-error/master.svg)](https://travis-ci.org/pugjs/pug-error)
-[![Dependency Status](https://img.shields.io/david/pugjs/pug-error.svg)](https://david-dm.org/pugjs/pug-error)
+[![Dependencies Status](https://david-dm.org/pugjs/pug/status.svg?path=packages/pug-error)](https://david-dm.org/pugjs/pug?path=packages/pug-error)
 [![NPM version](https://img.shields.io/npm/v/pug-error.svg)](https://www.npmjs.org/package/pug-error)
 
 ## Installation

--- a/packages/pug-filters/README.md
+++ b/packages/pug-filters/README.md
@@ -3,7 +3,8 @@
 Code for processing filters in pug templates
 
 [![Build Status](https://img.shields.io/travis/pugjs/pug-filters/master.svg)](https://travis-ci.org/pugjs/pug-filters)
-[![Dependency Status](https://img.shields.io/david/pugjs/pug-filters.svg)](https://david-dm.org/pugjs/pug-filters)
+[![Dependencies Status](https://david-dm.org/pugjs/pug/status.svg?path=packages/pug-filters)](https://david-dm.org/pugjs/pug?path=packages/pug-filters)
+[![DevDependencies Status](https://david-dm.org/pugjs/pug/dev-status.svg?path=packages/pug-filters)](https://david-dm.org/pugjs/pug?path=packages/pug-filters&type=dev)
 [![NPM version](https://img.shields.io/npm/v/pug-filters.svg)](https://www.npmjs.org/package/pug-filters)
 
 ## Installation

--- a/packages/pug-lexer/README.md
+++ b/packages/pug-lexer/README.md
@@ -3,7 +3,8 @@
 The pug lexer.  This module is responsible for taking a string and converting it into an array of tokens.
 
 [![Build Status](https://img.shields.io/travis/pugjs/pug-lexer/master.svg)](https://travis-ci.org/pugjs/pug-lexer)
-[![Dependency Status](https://img.shields.io/david/pugjs/pug-lexer.svg)](https://david-dm.org/pugjs/pug-lexer)
+[![Dependencies Status](https://david-dm.org/pugjs/pug/status.svg?path=packages/pug-lexer)](https://david-dm.org/pugjs/pug?path=packages/pug-lexer)
+[![DevDependencies Status](https://david-dm.org/pugjs/pug/dev-status.svg?path=packages/pug-lexer)](https://david-dm.org/pugjs/pug?path=packages/pug-lexer&type=dev)
 [![NPM version](https://img.shields.io/npm/v/pug-lexer.svg)](https://www.npmjs.org/package/pug-lexer)
 [![Coverage Status](https://img.shields.io/codecov/c/github/pugjs/pug-lexer.svg)](https://codecov.io/gh/pugjs/pug-lexer)
 

--- a/packages/pug-linker/README.md
+++ b/packages/pug-linker/README.md
@@ -3,7 +3,8 @@
 Link multiple pug ASTs together using include/extends
 
 [![Build Status](https://img.shields.io/travis/pugjs/pug-linker/master.svg)](https://travis-ci.org/pugjs/pug-linker)
-[![Dependency Status](https://img.shields.io/david/pugjs/pug-linker.svg)](https://david-dm.org/pugjs/pug-linker)
+[![Dependencies Status](https://david-dm.org/pugjs/pug/status.svg?path=packages/pug-linker)](https://david-dm.org/pugjs/pug?path=packages/pug-linker)
+[![DevDependencies Status](https://david-dm.org/pugjs/pug/dev-status.svg?path=packages/pug-linker)](https://david-dm.org/pugjs/pug?path=packages/pug-linker&type=dev)
 [![NPM version](https://img.shields.io/npm/v/pug-linker.svg)](https://www.npmjs.org/package/pug-linker)
 
 ## Installation

--- a/packages/pug-load/README.md
+++ b/packages/pug-load/README.md
@@ -3,7 +3,8 @@
 The pug loader is responsible for loading the depenendencies of a given pug file.  It adds `fullPath` and `str` properties to every `Include` and `Extends` node.  It also adds an `ast` property to any `Include` nodes that are loading pug and any `Extends` nodes.  It then recursively loads the dependencies of any of those included files.
 
 [![Build Status](https://img.shields.io/travis/pugjs/pug-load/master.svg)](https://travis-ci.org/pugjs/pug-load)
-[![Dependency Status](https://img.shields.io/david/pugjs/pug-load.svg)](https://david-dm.org/pugjs/pug-load)
+[![Dependencies Status](https://david-dm.org/pugjs/pug/status.svg?path=packages/pug-load)](https://david-dm.org/pugjs/pug?path=packages/pug-load)
+[![DevDependencies Status](https://david-dm.org/pugjs/pug/dev-status.svg?path=packages/pug-load)](https://david-dm.org/pugjs/pug?path=packages/pug-load&type=dev)
 [![NPM version](https://img.shields.io/npm/v/pug-load.svg)](https://www.npmjs.org/package/pug-load)
 [![Coverage Status](https://img.shields.io/codecov/c/github/pugjs/pug-load.svg)](https://codecov.io/gh/pugjs/pug-load)
 

--- a/packages/pug-parser/README.md
+++ b/packages/pug-parser/README.md
@@ -3,7 +3,8 @@
 The pug parser (takes an array of tokens and converts it to an abstract syntax tree)
 
 [![Build Status](https://img.shields.io/travis/pugjs/pug-parser/master.svg)](https://travis-ci.org/pugjs/pug-parser)
-[![Dependency Status](https://img.shields.io/david/pugjs/pug-parser.svg)](https://david-dm.org/pugjs/pug-parser)
+[![Dependencies Status](https://david-dm.org/pugjs/pug/status.svg?path=packages/pug-parser)](https://david-dm.org/pugjs/pug?path=packages/pug-parser)
+[![DevDependencies Status](https://david-dm.org/pugjs/pug/dev-status.svg?path=packages/pug-parser)](https://david-dm.org/pugjs/pug?path=packages/pug-parser&type=dev)
 [![NPM version](https://img.shields.io/npm/v/pug-parser.svg)](https://www.npmjs.org/package/pug-parser)
 
 ## Installation

--- a/packages/pug-runtime/README.md
+++ b/packages/pug-runtime/README.md
@@ -3,7 +3,8 @@
 The runtime components for the pug templating language
 
 [![Build Status](https://img.shields.io/travis/pugjs/pug-runtime/master.svg)](https://travis-ci.org/pugjs/pug-runtime)
-[![Dependency Status](https://img.shields.io/david/pugjs/pug-runtime.svg)](https://david-dm.org/pugjs/pug-runtime)
+[![Dependencies Status](https://david-dm.org/pugjs/pug/status.svg?path=packages/pug-runtime)](https://david-dm.org/pugjs/pug?path=packages/pug-runtime)
+[![DevDependencies Status](https://david-dm.org/pugjs/pug/dev-status.svg?path=packages/pug-runtime)](https://david-dm.org/pugjs/pug?path=packages/pug-runtime&type=dev)
 [![NPM version](https://img.shields.io/npm/v/pug-runtime.svg)](https://www.npmjs.org/package/pug-runtime)
 
 ## Installation

--- a/packages/pug-strip-comments/README.md
+++ b/packages/pug-strip-comments/README.md
@@ -3,7 +3,8 @@
 Strips comments from Pug token stream
 
 [![Build Status](https://img.shields.io/travis/pugjs/pug-strip-comments/master.svg)](https://travis-ci.org/pugjs/pug-strip-comments)
-[![Dependency Status](https://img.shields.io/david/pugjs/pug-strip-comments.svg)](https://david-dm.org/pugjs/pug-strip-comments)
+[![Dependencies Status](https://david-dm.org/pugjs/pug/status.svg?path=packages/pug-strip-comments)](https://david-dm.org/pugjs/pug?path=packages/pug-strip-comments)
+[![DevDependencies Status](https://david-dm.org/pugjs/pug/dev-status.svg?path=packages/pug-strip-comments)](https://david-dm.org/pugjs/pug?path=packages/pug-strip-comments&type=dev)
 [![NPM version](https://img.shields.io/npm/v/pug-strip-comments.svg)](https://www.npmjs.org/package/pug-strip-comments)
 
 ## Installation

--- a/packages/pug-walk/README.md
+++ b/packages/pug-walk/README.md
@@ -3,7 +3,8 @@
 Walk and transform a Pug AST
 
 [![Build Status](https://img.shields.io/travis/pugjs/pug-walk/master.svg)](https://travis-ci.org/pugjs/pug-walk)
-[![Dependency Status](https://img.shields.io/david/pugjs/pug-walk.svg)](https://david-dm.org/pugjs/pug-walk)
+[![Dependencies Status](https://david-dm.org/pugjs/pug/status.svg?path=packages/pug-walk)](https://david-dm.org/pugjs/pug?path=packages/pug-walk)
+[![DevDependencies Status](https://david-dm.org/pugjs/pug/dev-status.svg?path=packages/pug-walk)](https://david-dm.org/pugjs/pug?path=packages/pug-walk&type=dev)
 [![npm version](https://img.shields.io/npm/v/pug-walk.svg)](https://www.npmjs.org/package/pug-walk)
 [![Coverage Status](https://img.shields.io/codecov/c/github/pugjs/pug-walk/master.svg)](https://codecov.io/gh/pugjs/pug-walk/branch/master)
 

--- a/packages/pug/README.md
+++ b/packages/pug/README.md
@@ -14,8 +14,8 @@ Full documentation is at [pugjs.org](https://pugjs.org/)
 
  [![Build Status](https://img.shields.io/travis/pugjs/pug/master.svg?style=flat)](https://travis-ci.org/pugjs/pug)
  [![Coverage Status](https://img.shields.io/coveralls/pugjs/pug/master.svg?style=flat)](https://coveralls.io/r/pugjs/pug?branch=master)
- [![Dependency Status](https://img.shields.io/david/pugjs/pug.svg?style=flat)](https://david-dm.org/pugjs/pug)
- [![devDependencies Status](https://img.shields.io/david/dev/pugjs/pug.svg?style=flat)](https://david-dm.org/pugjs/pug?type=dev)
+ [![Dependency Status](https://david-dm.org/pugjs/pug/status.svg?path=packages/pug)](https://david-dm.org/pugjs/pug?path=packages/pug)
+ [![DevDependencies Status](https://david-dm.org/pugjs/pug/dev-status.svg?path=packages/pug)](https://david-dm.org/pugjs/pug?path=packages/pug&type=dev)
  [![NPM version](https://img.shields.io/npm/v/pug.svg?style=flat)](https://www.npmjs.com/package/pug)
  [![Join Gitter Chat](https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg?style=flat)](https://gitter.im/pugjs/pug?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 


### PR DESCRIPTION
For packages in a mono-repo,  david-dm.org requires a query parameter that identifies the location of the package.json.