### PR TITLE
Allow spread operator in attributes

### DIFF
--- a/packages/pug-lexer/index.js
+++ b/packages/pug-lexer/index.js
@@ -1218,7 +1218,11 @@ Lexer.prototype = {
             if (!this.whitespaceRe.test(str[x])) {
               // if it is a JavaScript punctuator, then assume that it is
               // a part of the value
-              if((!characterParser.isPunctuator(str[x]) || quoteRe.test(str[x]) || str[x] === ':') && this.assertExpression(val, true)){
+              const isNotPunctuator = !characterParser.isPunctuator(str[x])
+              const isQuote = quoteRe.test(str[x])
+              const isColon = str[x] === ':'
+              const isSpreadOperator = str[x] + str[x + 1] + str[x + 2] === '...'
+              if ((isNotPunctuator || isQuote || isColon || isSpreadOperator) && this.assertExpression(val, true)) {
                 done = true;
               }
               break;

--- a/packages/pug-lexer/test/__snapshots__/index.test.js.snap
+++ b/packages/pug-lexer/test/__snapshots__/index.test.js.snap
@@ -1303,12 +1303,376 @@ Array [
     "loc": Object {
       "end": Object {
         "column": 1,
-        "line": 18,
+        "line": 19,
       },
       "filename": "<basedir>/packages/pug-lexer/test/cases/attrs.js.pug",
       "start": Object {
         "column": 1,
-        "line": 18,
+        "line": 19,
+      },
+    },
+    "type": "newline",
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 4,
+        "line": 19,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/attrs.js.pug",
+      "start": Object {
+        "column": 1,
+        "line": 19,
+      },
+    },
+    "type": "tag",
+    "val": "div",
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 5,
+        "line": 19,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/attrs.js.pug",
+      "start": Object {
+        "column": 4,
+        "line": 19,
+      },
+    },
+    "type": "start-attributes",
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 14,
+        "line": 19,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/attrs.js.pug",
+      "start": Object {
+        "column": 5,
+        "line": 19,
+      },
+    },
+    "mustEscape": true,
+    "name": "...object",
+    "type": "attribute",
+    "val": true,
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 15,
+        "line": 19,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/attrs.js.pug",
+      "start": Object {
+        "column": 14,
+        "line": 19,
+      },
+    },
+    "type": "end-attributes",
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 1,
+        "line": 20,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/attrs.js.pug",
+      "start": Object {
+        "column": 1,
+        "line": 20,
+      },
+    },
+    "type": "newline",
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 4,
+        "line": 20,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/attrs.js.pug",
+      "start": Object {
+        "column": 1,
+        "line": 20,
+      },
+    },
+    "type": "tag",
+    "val": "div",
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 5,
+        "line": 20,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/attrs.js.pug",
+      "start": Object {
+        "column": 4,
+        "line": 20,
+      },
+    },
+    "type": "start-attributes",
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 14,
+        "line": 20,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/attrs.js.pug",
+      "start": Object {
+        "column": 5,
+        "line": 20,
+      },
+    },
+    "mustEscape": true,
+    "name": "...object",
+    "type": "attribute",
+    "val": true,
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 28,
+        "line": 20,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/attrs.js.pug",
+      "start": Object {
+        "column": 15,
+        "line": 20,
+      },
+    },
+    "mustEscape": true,
+    "name": "after",
+    "type": "attribute",
+    "val": "\\"after\\"",
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 29,
+        "line": 20,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/attrs.js.pug",
+      "start": Object {
+        "column": 28,
+        "line": 20,
+      },
+    },
+    "type": "end-attributes",
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 1,
+        "line": 21,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/attrs.js.pug",
+      "start": Object {
+        "column": 1,
+        "line": 21,
+      },
+    },
+    "type": "newline",
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 4,
+        "line": 21,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/attrs.js.pug",
+      "start": Object {
+        "column": 1,
+        "line": 21,
+      },
+    },
+    "type": "tag",
+    "val": "div",
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 5,
+        "line": 21,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/attrs.js.pug",
+      "start": Object {
+        "column": 4,
+        "line": 21,
+      },
+    },
+    "type": "start-attributes",
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 20,
+        "line": 21,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/attrs.js.pug",
+      "start": Object {
+        "column": 5,
+        "line": 21,
+      },
+    },
+    "mustEscape": true,
+    "name": "before",
+    "type": "attribute",
+    "val": "\\"before\\"",
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 30,
+        "line": 21,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/attrs.js.pug",
+      "start": Object {
+        "column": 21,
+        "line": 21,
+      },
+    },
+    "mustEscape": true,
+    "name": "...object",
+    "type": "attribute",
+    "val": true,
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 31,
+        "line": 21,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/attrs.js.pug",
+      "start": Object {
+        "column": 30,
+        "line": 21,
+      },
+    },
+    "type": "end-attributes",
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 1,
+        "line": 22,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/attrs.js.pug",
+      "start": Object {
+        "column": 1,
+        "line": 22,
+      },
+    },
+    "type": "newline",
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 4,
+        "line": 22,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/attrs.js.pug",
+      "start": Object {
+        "column": 1,
+        "line": 22,
+      },
+    },
+    "type": "tag",
+    "val": "div",
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 5,
+        "line": 22,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/attrs.js.pug",
+      "start": Object {
+        "column": 4,
+        "line": 22,
+      },
+    },
+    "type": "start-attributes",
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 20,
+        "line": 22,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/attrs.js.pug",
+      "start": Object {
+        "column": 5,
+        "line": 22,
+      },
+    },
+    "mustEscape": true,
+    "name": "before",
+    "type": "attribute",
+    "val": "\\"before\\"",
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 30,
+        "line": 22,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/attrs.js.pug",
+      "start": Object {
+        "column": 21,
+        "line": 22,
+      },
+    },
+    "mustEscape": true,
+    "name": "...object",
+    "type": "attribute",
+    "val": true,
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 44,
+        "line": 22,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/attrs.js.pug",
+      "start": Object {
+        "column": 31,
+        "line": 22,
+      },
+    },
+    "mustEscape": true,
+    "name": "after",
+    "type": "attribute",
+    "val": "\\"after\\"",
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 45,
+        "line": 22,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/attrs.js.pug",
+      "start": Object {
+        "column": 44,
+        "line": 22,
+      },
+    },
+    "type": "end-attributes",
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 1,
+        "line": 23,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/attrs.js.pug",
+      "start": Object {
+        "column": 1,
+        "line": 23,
       },
     },
     "type": "newline",
@@ -1317,12 +1681,12 @@ Array [
     "loc": Object {
       "end": Object {
         "column": 1,
-        "line": 18,
+        "line": 23,
       },
       "filename": "<basedir>/packages/pug-lexer/test/cases/attrs.js.pug",
       "start": Object {
         "column": 1,
-        "line": 18,
+        "line": 23,
       },
     },
     "type": "eos",

--- a/packages/pug-lexer/test/cases/attrs.js.pug
+++ b/packages/pug-lexer/test/cases/attrs.js.pug
@@ -15,3 +15,8 @@ a.tag-class(class = ['class1', 'class2'])
 div(id=id)&attributes({foo: 'bar'})
 - var bar = null
 div(foo=null bar=bar)&attributes({baz: 'baz'})
+
+div(...object)
+div(...object after="after")
+div(before="before" ...object)
+div(before="before" ...object after="after")


### PR DESCRIPTION
That is a tiny fix to have better supporting of spread operator in attributes.

For example the following case threw a SyntaxError:
```pug
div(anything ...props)
```

Now that works. It will help me to provide better experience for react users.