### PR TITLE
Adding 'each .. of' syntax

### DIFF
--- a/packages/pug-code-gen/index.js
+++ b/packages/pug-code-gen/index.js
@@ -65,7 +65,6 @@ function Compiler(node, options) {
   this.mixins = {};
   this.dynamicMixins = false;
   this.eachCount = 0;
-  this.eachOfCount = 0;
   if (options.doctype) this.setDoctype(options.doctype);
   this.runtimeFunctionsUsed = [];
   this.inlineRuntimeFunctions = options.inlineRuntimeFunctions || false;

--- a/packages/pug-code-gen/index.js
+++ b/packages/pug-code-gen/index.js
@@ -767,6 +767,52 @@ Compiler.prototype = {
     this.buf.push('  }\n}).call(this);\n');
   },
 
+  visitEachOf: function(each){
+    var indexVarName = each.key || 'pug_index' + this.eachCount;
+    this.eachCount++;
+
+    this.buf.push(''
+      + '// iterate ' + each.obj + '\n'
+      + ';(function(){\n'
+      + '  var $$obj = ' + each.obj + ';\n'
+      + '  if (\'number\' == typeof $$obj.length) {');
+
+    if (each.alternate) {
+      this.buf.push('    if ($$obj.length) {');
+    }
+
+    this.buf.push(''
+      + '      for (var ' + indexVarName + ' = 0, $$l = $$obj.length; ' + indexVarName + ' < $$l; ' + indexVarName + '++) {\n'
+      + '        var ' + each.val + ' = $$obj[' + indexVarName + '];');
+
+    this.visit(each.block, each);
+
+    this.buf.push('      }');
+
+    if (each.alternate) {
+      this.buf.push('    } else {');
+      this.visit(each.alternate, each);
+      this.buf.push('    }');
+    }
+
+    this.buf.push(''
+      + '  } else {\n'
+      + '    var $$l = 0;\n'
+      + '    for (var ' + indexVarName + ' of $$obj) {\n'
+      + '      $$l++;\n'
+      + '      var ' + each.val + ' = ' + indexVarName + ';');
+
+    this.visit(each.block, each);
+
+    this.buf.push('    }');
+    if (each.alternate) {
+      this.buf.push('    if ($$l === 0) {');
+      this.visit(each.alternate, each);
+      this.buf.push('    }');
+    }
+    this.buf.push('  }\n}).call(this);\n');
+  },
+
   /**
    * Visit `attrs`.
    *

--- a/packages/pug-code-gen/index.js
+++ b/packages/pug-code-gen/index.js
@@ -769,34 +769,13 @@ Compiler.prototype = {
   },
 
   visitEachOf: function(each){
-    var valVarName = 'pug_val' + this.eachOfCount;
-    if (each.key) {
-      var keyVarName = 'pug_key' + this.eachOfCount
-    }
-    this.eachOfCount++;
-
     this.buf.push(''
       + '// iterate ' + each.obj + '\n'
-      + ';(function(){\n'
-      + '  var $$obj = ' + each.obj + ';\n'
-      + '  var $$l = 0;\n')
-    if (each.key) {
-      this.buf.push('  for (const [' + keyVarName + ', ' + valVarName + '] of $$obj) {\n');
-    } else {
-      this.buf.push('  for (const ' + valVarName + ' of $$obj) {\n');
-    }
-    this.buf.push('    $$l++;\n');
-    if (each.key) {
-      this.buf.push(''
-        + '    var ' + each.key + ' = ' + valVarName + ';'
-        + '    var ' + each.val + ' = ' + keyVarName + ';');
-    } else {
-      this.buf.push('    var ' + each.val + ' = ' + valVarName + ';')
-    }
+      + 'for (const ' + each.val + ' of ' + each.obj + ') {\n')
 
     this.visit(each.block, each);
 
-    this.buf.push('  }\n}).call(this);\n');
+    this.buf.push('}\n');
   },
 
   /**

--- a/packages/pug-lexer/index.js
+++ b/packages/pug-lexer/index.js
@@ -977,14 +977,14 @@ Lexer.prototype = {
 
   eachOf: function() {
     var captures;
-    if (captures = /^(?:each|for) +\[?([a-zA-Z_$][\w$]*)(?: *, *([a-zA-Z_$][\w$]*))?\]? * of *([^\n]+)/.exec(this.input)) {
+    if (captures = /^(?:each|for) (.*) * of *([^\n]+)/.exec(this.input)) {
       this.consume(captures[0].length);
       var tok = this.tok('eachOf', captures[1]);
-      tok.key = captures[2] || null;
-      this.incrementColumn(captures[0].length - captures[3].length);
-      this.assertExpression(captures[3])
-      tok.code = captures[3];
-      this.incrementColumn(captures[3].length);
+      tok.value = captures[1] || null;
+      this.incrementColumn(captures[0].length - captures[2].length);
+      this.assertExpression(captures[2])
+      tok.code = captures[2];
+      this.incrementColumn(captures[2].length);
       this.tokens.push(this.tokEnd(tok));
       return true;
     }

--- a/packages/pug-lexer/index.js
+++ b/packages/pug-lexer/index.js
@@ -991,7 +991,7 @@ Lexer.prototype = {
     if (captures = /^- *(?:each|for) +([a-zA-Z_$][\w$]*)(?: *, *([a-zA-Z_$][\w$]*))? +of +([^\n]+)/.exec(this.input)) {
       this.error(
         'MALFORMED_EACH',
-        'Pug each and for should no longer be prefixed with a dash ("-"). They are pug keywords and not part of JavaScript.'
+        'Pug each and for should not be prefixed with a dash ("-"). They are pug keywords and not part of JavaScript.'
       );
     }
   },

--- a/packages/pug-lexer/index.js
+++ b/packages/pug-lexer/index.js
@@ -972,6 +972,31 @@ Lexer.prototype = {
   },
 
   /**
+   * EachOf.
+   */
+
+  eachOf: function() {
+    var captures;
+    if (captures = /^(?:each|for) +([a-zA-Z_$][\w$]*)(?: *, *([a-zA-Z_$][\w$]*))? * of *([^\n]+)/.exec(this.input)) {
+      this.consume(captures[0].length);
+      var tok = this.tok('eachOf', captures[1]);
+      tok.key = captures[2] || null;
+      this.incrementColumn(captures[0].length - captures[3].length);
+      this.assertExpression(captures[3])
+      tok.code = captures[3];
+      this.incrementColumn(captures[3].length);
+      this.tokens.push(this.tokEnd(tok));
+      return true;
+    }
+    if (captures = /^- *(?:each|for) +([a-zA-Z_$][\w$]*)(?: *, *([a-zA-Z_$][\w$]*))? +of +([^\n]+)/.exec(this.input)) {
+      this.error(
+        'MALFORMED_EACH',
+        'Pug each and for should no longer be prefixed with a dash ("-"). They are pug keywords and not part of JavaScript.'
+      );
+    }
+  },
+
+  /**
    * Code.
    */
 
@@ -1485,6 +1510,7 @@ Lexer.prototype = {
       || this.callLexerFunction('mixin')
       || this.callLexerFunction('call')
       || this.callLexerFunction('conditional')
+      || this.callLexerFunction('eachOf')
       || this.callLexerFunction('each')
       || this.callLexerFunction('while')
       || this.callLexerFunction('tag')

--- a/packages/pug-lexer/index.js
+++ b/packages/pug-lexer/index.js
@@ -977,15 +977,23 @@ Lexer.prototype = {
 
   eachOf: function() {
     var captures;
-    if (captures = /^(?:each|for) (.*) * of *([^\n]+)/.exec(this.input)) {
+    if (captures = /^(?:each|for) (.*) of *([^\n]+)/.exec(this.input)) {
       this.consume(captures[0].length);
       var tok = this.tok('eachOf', captures[1]);
-      tok.value = captures[1] || null;
+      tok.value = captures[1];
       this.incrementColumn(captures[0].length - captures[2].length);
       this.assertExpression(captures[2])
       tok.code = captures[2];
       this.incrementColumn(captures[2].length);
       this.tokens.push(this.tokEnd(tok));
+
+      if (!(/^[a-zA-Z_$][\w$]*$/.test(tok.value.trim()) || /^\[ *[a-zA-Z_$][\w$]* *\, *[a-zA-Z_$][\w$]* *\]$/.test(tok.value.trim()))) {
+        this.error(
+          'MALFORMED_EACH_OF_LVAL',
+          'The value variable for each must either be a valid identifier (e.g. `item`) or a pair of identifiers in square brackets (e.g. `[key, value]`).'
+        );
+      }
+      
       return true;
     }
     if (captures = /^- *(?:each|for) +([a-zA-Z_$][\w$]*)(?: *, *([a-zA-Z_$][\w$]*))? +of +([^\n]+)/.exec(this.input)) {

--- a/packages/pug-lexer/index.js
+++ b/packages/pug-lexer/index.js
@@ -977,7 +977,7 @@ Lexer.prototype = {
 
   eachOf: function() {
     var captures;
-    if (captures = /^(?:each|for) +([a-zA-Z_$][\w$]*)(?: *, *([a-zA-Z_$][\w$]*))? * of *([^\n]+)/.exec(this.input)) {
+    if (captures = /^(?:each|for) +\[?([a-zA-Z_$][\w$]*)(?: *, *([a-zA-Z_$][\w$]*))?\]? * of *([^\n]+)/.exec(this.input)) {
       this.consume(captures[0].length);
       var tok = this.tok('eachOf', captures[1]);
       tok.key = captures[2] || null;

--- a/packages/pug-lexer/test/check-lexer-functions.test.js
+++ b/packages/pug-lexer/test/check-lexer-functions.test.js
@@ -23,6 +23,7 @@ var lexerFunctions = {
   doctype: true,
   dot: true,
   each: true,
+  eachOf: true,
   eos: true,
   endInterpolation: true,
   extends: true,

--- a/packages/pug-parser/index.js
+++ b/packages/pug-parser/index.js
@@ -234,6 +234,8 @@ Parser.prototype = {
         return this.parseDot();
       case 'each':
         return this.parseEach();
+      case 'eachOf':
+        return this.parseEachOf();
       case 'code':
         return this.parseCode();
       case 'blockcode':
@@ -761,6 +763,24 @@ loop:
     return node;
   },
 
+  parseEachOf: function(){
+    var tok = this.expect('eachOf');
+    var node = {
+      type: 'EachOf',
+      obj: tok.code,
+      val: tok.val,
+      key: tok.key,
+      block: this.block(),
+      line: tok.loc.start.line,
+      column: tok.loc.start.column,
+      filename: this.filename
+    };
+    if (this.peek().type == 'else') {
+      this.advance();
+      node.alternate = this.block();
+    }
+    return node;
+  },
   /**
    * 'extends' name
    */

--- a/packages/pug-parser/index.js
+++ b/packages/pug-parser/index.js
@@ -775,10 +775,6 @@ loop:
       column: tok.loc.start.column,
       filename: this.filename
     };
-    if (this.peek().type == 'else') {
-      this.advance();
-      node.alternate = this.block();
-    }
     return node;
   },
   /**

--- a/packages/pug-parser/index.js
+++ b/packages/pug-parser/index.js
@@ -769,7 +769,6 @@ loop:
       type: 'EachOf',
       obj: tok.code,
       val: tok.val,
-      key: tok.key,
       block: this.block(),
       line: tok.loc.start.line,
       column: tok.loc.start.column,

--- a/packages/pug-walk/index.js
+++ b/packages/pug-walk/index.js
@@ -56,6 +56,14 @@ function walkAST(ast, before, after, options) {
         ast.alternate = walkAST(ast.alternate, before, after, options);
       }
       break;
+    case 'EachOf':
+      if (ast.block) {
+        ast.block = walkAST(ast.block, before, after, options);
+      }
+      if (ast.alternate) {
+        ast.alternate = walkAST(ast.alternate, before, after, options);
+      }
+      break;
     case 'Conditional':
       if (ast.consequent) {
         ast.consequent = walkAST(ast.consequent, before, after, options);

--- a/packages/pug-walk/index.js
+++ b/packages/pug-walk/index.js
@@ -60,9 +60,6 @@ function walkAST(ast, before, after, options) {
       if (ast.block) {
         ast.block = walkAST(ast.block, before, after, options);
       }
-      if (ast.alternate) {
-        ast.alternate = walkAST(ast.alternate, before, after, options);
-      }
       break;
     case 'Conditional':
       if (ast.consequent) {


### PR DESCRIPTION
This PR adds support for iterating over maps and other iterable objects with the JS syntax `each var of map`. This example patches issue #3170. The syntax `each var of map` and `for var of map` has been introduced, but `each` and `for` can be used interchangeably, like with the original each syntax. 

All tests run and pass, but I haven't added any tests except for a small fix to recognise the `eachOf` function is the `pug-lexer`.

## Example Code
### JS
```js
var pug = require('pug');

var map = new Map([['foo', 'bar'], ['a', 'b']]);

var html = pug.renderFile('code.pug', { some_iterable: map });

console.log(html);
```
### Pug
```
h1 Pug iteration test file
each el of some_iterable
     p= el[0]
     p= el[1]
```
### Output
```html
<h1>Pug iteration test file</h1><p>foo</p><p>bar</p><p>a</p><p>b</p>
```