### PR TITLE
Adding unit tests for 'each .. of'

### DIFF
--- a/packages/pug/test/eachOf/__snapshots__/index.test.js.snap
+++ b/packages/pug/test/eachOf/__snapshots__/index.test.js.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Proper Usage Brackets 1`] = `"<li>a</li><li>b</li><li>foo</li><li>bar</li>"`;
+
+exports[`Proper Usage No Brackets 1`] = `"<li>a</li><li>b</li><li>foo</li><li>bar</li>"`;

--- a/packages/pug/test/eachOf/error/left-side.pug
+++ b/packages/pug/test/eachOf/error/left-side.pug
@@ -1,0 +1,3 @@
+each [key, val of users
+  li= key
+  li= val

--- a/packages/pug/test/eachOf/error/no-brackets.pug
+++ b/packages/pug/test/eachOf/error/no-brackets.pug
@@ -1,0 +1,3 @@
+each key, val of users
+  li= key
+  li= val

--- a/packages/pug/test/eachOf/error/one-val.pug
+++ b/packages/pug/test/eachOf/error/one-val.pug
@@ -1,0 +1,3 @@
+each [key] of users
+  li= key
+  li= val

--- a/packages/pug/test/eachOf/error/right-side.pug
+++ b/packages/pug/test/eachOf/error/right-side.pug
@@ -1,0 +1,3 @@
+each key, val] of users
+  li= key
+  li= val

--- a/packages/pug/test/eachOf/index.test.js
+++ b/packages/pug/test/eachOf/index.test.js
@@ -1,0 +1,52 @@
+const pug = require('../../');
+
+describe('Inproper Usage', () => {
+  test('Only left-side bracket', () => {
+    expect(
+      () => pug.compileFile(
+        __dirname + '/error/left-side.pug'
+      )
+    ).toThrow('The value variable for each must either be a valid identifier (e.g. `item`) or a pair of identifiers in square brackets (e.g. `[key, value]`).');
+  })
+  test('Only right-side bracket', () => {
+    expect(
+      () => pug.compileFile(
+        __dirname + '/error/right-side.pug'
+      )
+    ).toThrow('The value variable for each must either be a valid identifier (e.g. `item`) or a pair of identifiers in square brackets (e.g. `[key, value]`).');
+  })
+  test('Only one value inside brackets', () => {
+    expect(
+      () => pug.compileFile(
+        __dirname + '/error/one-val.pug'
+      )
+    ).toThrow('The value variable for each must either be a valid identifier (e.g. `item`) or a pair of identifiers in square brackets (e.g. `[key, value]`).');
+  })
+  test('No brackets', () => {
+    expect(
+      () => pug.compileFile(
+        __dirname + '/error/no-brackets.pug'
+      )
+    ).toThrow('The value variable for each must either be a valid identifier (e.g. `item`) or a pair of identifiers in square brackets (e.g. `[key, value]`).');
+  })
+})
+describe('Proper Usage', () => {
+  test('Brackets', () => {
+    const html = pug.renderFile(
+      __dirname + '/passing/brackets.pug',
+      {
+        users: new Map([['a', 'b'], ['foo', 'bar']])
+      }
+    )
+    expect(html).toMatchSnapshot();
+  })
+  test('No Brackets', () => {
+    const html = pug.renderFile(
+      __dirname + '/passing/no-brackets.pug',
+      {
+        users: new Map([['a', 'b'], ['foo', 'bar']])
+      }
+    )
+    expect(html).toMatchSnapshot();
+  })
+})

--- a/packages/pug/test/eachOf/passing/brackets.pug
+++ b/packages/pug/test/eachOf/passing/brackets.pug
@@ -1,0 +1,3 @@
+each [key, val] of users
+  li= key
+  li= val

--- a/packages/pug/test/eachOf/passing/no-brackets.pug
+++ b/packages/pug/test/eachOf/passing/no-brackets.pug
@@ -1,0 +1,3 @@
+each data of users
+  li= data[0]
+  li= data[1]


### PR DESCRIPTION
This PR adds unit tests for the 'each .. of' syntax, added in #3179. 

It tests to ensure syntax like `each [key, value of map` does throw an error and that the intended usage does remain working. Two Jest snapshots have been added for the two tests that do output HTML.

The tests are located in `/packages/pug/tests/eachOf/`, but if there would be a better place for the tests I would be happy to move them to another folder.
 