### PR TITLE
feat: improve error message for malformed each

### DIFF
--- a/packages/pug-lexer/index.js
+++ b/packages/pug-lexer/index.js
@@ -1053,7 +1053,16 @@ Lexer.prototype = {
     }
     const name = /^each\b/.exec(this.input) ? 'each' : 'for';
     if (this.scan(/^(?:each|for)\b/)) {
-      this.error('MALFORMED_EACH', 'This `' + name + '` has a syntax error. `' + name + '` statements should be of the form: `' + name + ' VARIABLE_NAME of JS_EXPRESSION`');
+      this.error(
+        'MALFORMED_EACH',
+        'This `' +
+          name +
+          '` has a syntax error. `' +
+          name +
+          '` statements should be of the form: `' +
+          name +
+          ' VARIABLE_NAME of JS_EXPRESSION`'
+      );
     }
     if (
       (captures = /^- *(?:each|for) +([a-zA-Z_$][\w$]*)(?: *, *([a-zA-Z_$][\w$]*))? +in +([^\n]+)/.exec(

--- a/packages/pug-lexer/index.js
+++ b/packages/pug-lexer/index.js
@@ -1051,8 +1051,9 @@ Lexer.prototype = {
       this.tokens.push(this.tokEnd(tok));
       return true;
     }
+    const name = /^each\b/.exec(this.input) ? 'each' : 'for';
     if (this.scan(/^(?:each|for)\b/)) {
-      this.error('MALFORMED_EACH', 'malformed each');
+      this.error('MALFORMED_EACH', 'This `' + name + '` has a syntax error. `' + name + '` statements should be of the form: `' + name + ' VARIABLE_NAME of JS_EXPRESSION`');
     }
     if (
       (captures = /^- *(?:each|for) +([a-zA-Z_$][\w$]*)(?: *, *([a-zA-Z_$][\w$]*))? +in +([^\n]+)/.exec(

--- a/packages/pug-lexer/test/__snapshots__/index.test.js.snap
+++ b/packages/pug-lexer/test/__snapshots__/index.test.js.snap
@@ -28680,7 +28680,7 @@ Object {
   "code": "PUG:MALFORMED_EACH",
   "column": 5,
   "line": 1,
-  "msg": "malformed each",
+  "msg": "This \`each\` has a syntax error. \`each\` statements should be of the form: \`each VARIABLE_NAME of JS_EXPRESSION\`",
 }
 `;
 


### PR DESCRIPTION
It now includes a description of what `each` should look like. We guide people towards the newer `each ... of ...` syntax, rather than the older `each ... in ...` syntax.