### PR TITLE
Fix package.json `repository` definition

### DIFF
--- a/packages/pug-attrs/package.json
+++ b/packages/pug-attrs/package.json
@@ -15,7 +15,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/pugjs/pug/tree/master/packages/pug-attrs"
+    "url": "https://github.com/pugjs/pug.git",
+    "directory": "packages/pug-attrs"
   },
   "author": "Forbes Lindesay",
   "license": "MIT"

--- a/packages/pug-code-gen/package.json
+++ b/packages/pug-code-gen/package.json
@@ -20,7 +20,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/pugjs/pug/tree/master/packages/pug-code-gen"
+    "url": "https://github.com/pugjs/pug.git",
+    "directory": "packages/pug-code-gen"
   },
   "author": "Forbes Lindesay",
   "license": "MIT"

--- a/packages/pug-error/package.json
+++ b/packages/pug-error/package.json
@@ -10,7 +10,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/pugjs/pug/tree/master/packages/pug-error"
+    "url": "https://github.com/pugjs/pug.git",
+    "directory": "packages/pug-error"
   },
   "author": "Forbes Lindesay",
   "license": "MIT"

--- a/packages/pug-filters/package.json
+++ b/packages/pug-filters/package.json
@@ -33,7 +33,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/pugjs/pug/tree/master/packages/pug-filters"
+    "url": "https://github.com/pugjs/pug.git",
+    "directory": "packages/pug-filters"
   },
   "author": "Forbes Lindesay",
   "license": "MIT"

--- a/packages/pug-lexer/package.json
+++ b/packages/pug-lexer/package.json
@@ -18,7 +18,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/pugjs/pug/tree/master/packages/pug-lexer"
+    "url": "https://github.com/pugjs/pug.git",
+    "directory": "packages/pug-lexer"
   },
   "author": "ForbesLindesay",
   "license": "MIT"

--- a/packages/pug-linker/package.json
+++ b/packages/pug-linker/package.json
@@ -19,7 +19,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/pugjs/pug/tree/master/packages/pug-linker"
+    "url": "https://github.com/pugjs/pug.git",
+    "directory": "packages/pug-linker"
   },
   "author": "Forbes Lindesay",
   "license": "MIT"

--- a/packages/pug-load/package.json
+++ b/packages/pug-load/package.json
@@ -18,7 +18,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/pugjs/pug/tree/master/packages/pug-load"
+    "url": "https://github.com/pugjs/pug.git",
+    "directory": "packages/pug-load"
   },
   "author": "ForbesLindesay",
   "license": "MIT"

--- a/packages/pug-parser/package.json
+++ b/packages/pug-parser/package.json
@@ -18,7 +18,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/pugjs/pug/tree/master/packages/pug-parser"
+    "url": "https://github.com/pugjs/pug.git",
+    "directory": "packages/pug-parser"
   },
   "author": "ForbesLindesay",
   "license": "MIT"

--- a/packages/pug-runtime/package.json
+++ b/packages/pug-runtime/package.json
@@ -22,7 +22,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/pugjs/pug/tree/master/packages/pug-runtime"
+    "url": "https://github.com/pugjs/pug.git",
+    "directory": "packages/pug-runtime"
   },
   "browser": {
     "fs": false

--- a/packages/pug-strip-comments/package.json
+++ b/packages/pug-strip-comments/package.json
@@ -16,7 +16,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/pugjs/pug/tree/master/packages/pug-strip-comments"
+    "url": "https://github.com/pugjs/pug.git",
+    "directory": "packages/pug-strip-comments"
   },
   "author": "Timothy Gu <timothygu99@gmail.com>",
   "license": "MIT"

--- a/packages/pug-walk/package.json
+++ b/packages/pug-walk/package.json
@@ -14,7 +14,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/pugjs/pug/tree/master/packages/pug-walk"
+    "url": "https://github.com/pugjs/pug.git",
+    "directory": "packages/pug-walk"
   },
   "author": "ForbesLindesay",
   "license": "MIT"

--- a/packages/pug/package.json
+++ b/packages/pug/package.json
@@ -22,7 +22,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pugjs/pug/tree/master/packages/pug"
+    "url": "https://github.com/pugjs/pug.git",
+    "directory": "packages/pug"
   },
   "main": "lib",
   "dependencies": {


### PR DESCRIPTION
See https://docs.npmjs.com/files/package.json#repository. tl;dr: the `url` field here is supposed to be something that can be passed directly to Git. It cannot be something that will give you HTML.