### PR TITLE
Update dependencies

### DIFF
--- a/packages/pug-attrs/package.json
+++ b/packages/pug-attrs/package.json
@@ -6,7 +6,7 @@
     "pug"
   ],
   "dependencies": {
-    "constantinople": "^3.0.1",
+    "constantinople": "^4.0.1",
     "js-stringify": "^1.0.1",
     "pug-runtime": "^2.0.5"
   },

--- a/packages/pug-code-gen/package.json
+++ b/packages/pug-code-gen/package.json
@@ -6,13 +6,13 @@
     "pug"
   ],
   "dependencies": {
-    "constantinople": "^3.1.2",
+    "constantinople": "^4.0.1",
     "doctypes": "^1.1.0",
     "js-stringify": "^1.0.1",
     "pug-attrs": "^2.0.4",
     "pug-error": "^1.3.3",
     "pug-runtime": "^2.0.5",
-    "void-elements": "^2.0.1",
+    "void-elements": "^3.1.0",
     "with": "^5.0.0"
   },
   "files": [

--- a/packages/pug-filters/package.json
+++ b/packages/pug-filters/package.json
@@ -7,7 +7,7 @@
   ],
   "dependencies": {
     "clean-css": "^4.1.11",
-    "constantinople": "^3.0.1",
+    "constantinople": "^4.0.1",
     "jstransformer": "1.0.0",
     "pug-error": "^1.3.3",
     "pug-walk": "^1.1.8",

--- a/packages/pug-lexer/package.json
+++ b/packages/pug-lexer/package.json
@@ -11,7 +11,7 @@
     "pug-error": "^1.3.3"
   },
   "devDependencies": {
-    "acorn": "^3.0.4"
+    "acorn": "^7.1.0"
   },
   "files": [
     "index.js"

--- a/packages/pug-strip-comments/package.json
+++ b/packages/pug-strip-comments/package.json
@@ -9,7 +9,7 @@
     "pug-error": "^1.3.3"
   },
   "devDependencies": {
-    "line-json": "^1.0.0"
+    "line-json": "^2.0.0"
   },
   "files": [
     "index.js"

--- a/packages/pug/package.json
+++ b/packages/pug/package.json
@@ -44,7 +44,7 @@
     "jstransformer-uglify-js": "^1.1.1",
     "jstransformer-verbatim": "^1.0.0",
     "mkdirp": "^0.5.1",
-    "rimraf": "^2.2.8",
+    "rimraf": "^3.0.0",
     "uglify-js": "github:mishoo/UglifyJS2#1c15d0db456ce32f1b9b507aad97e5ee5c8285f7"
   },
   "files": [


### PR DESCRIPTION
This is a housekeeping PR to address some of the out-of-date dependencies per https://github.com/pugjs/pug#dependency-status.  It only includes updates that are not breaking pug tests.  I have verified these changes by running the following commands in order:
```
npm run clean
npm run bootstrap
npm run pretest
npm run test
npm run coverage
```


The output of `npm run test`:
```
> pug-monorepo@ pretest /mnt/c/temp/pug
> lerna run pretest

lerna notice cli v3.10.8
lerna info versioning independent
lerna info Executing command in 1 package: "yarn run pretest"
lerna info run Ran npm script 'pretest' in 'pug-runtime' in 1.3s:
yarn run v1.19.1
$ npm run prepublish

> pug-runtime@2.0.5 prepublish /mnt/c/temp/pug/packages/pug-runtime
> node prepublish

Done in 0.96s.
lerna success run Ran npm script 'pretest' in 1 package in 1.3s:
lerna success - pug-runtime
yasharf@Orcus:/mnt/c/temp/pug$ npm run test

> pug-monorepo@ pretest /mnt/c/temp/pug
> lerna run pretest

lerna notice cli v3.10.8
lerna info versioning independent
lerna info Executing command in 1 package: "yarn run pretest"
lerna info run Ran npm script 'pretest' in 'pug-runtime' in 1.3s:
yarn run v1.19.1
$ npm run prepublish

> pug-runtime@2.0.5 prepublish /mnt/c/temp/pug/packages/pug-runtime
> node prepublish

Done in 0.94s.
lerna success run Ran npm script 'pretest' in 1 package in 1.3s:
lerna success - pug-runtime

> pug-monorepo@ test /mnt/c/temp/pug
> jest

 PASS  packages/pug-runtime/test/index.test.js
 PASS  packages/pug-attrs/test/index.test.js
 PASS  packages/pug/test/error.reporting.test.js (5.641s)
 PASS  packages/pug-walk/test/index.test.js
 PASS  packages/pug-error/test/index.test.js
 PASS  packages/pug-lexer/test/check-lexer-functions.test.js
(node:6136) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
 PASS  packages/pug/test/pug.test.js (6.435s)
 PASS  packages/pug-strip-comments/test/index.test.js
 PASS  packages/pug-filters/test/filter-aliases.test.js
 PASS  packages/pug/test/eachOf/index.test.js
 PASS  packages/pug/test/run-syntax-errors.test.js
 PASS  packages/pug-linker/test/index.test.js
 PASS  packages/pug-filters/test/index.test.js
 PASS  packages/pug-lexer/test/index.test.js
 PASS  packages/pug-filters/test/per-filter-options-applied-to-nested-filters.test.js
 PASS  packages/pug-load/test/index.test.js
 PASS  packages/pug/test/extends-not-top-level/index.test.js
 PASS  packages/pug-parser/test/index.test.js
 PASS  packages/pug/test/run-es2015.test.js
 PASS  packages/pug/test/examples.test.js
 PASS  packages/pug/test/regression-2436/index.test.js
 PASS  packages/pug/test/markdown-it/index.test.js
 PASS  packages/pug/test/duplicate-block/index.test.js
 PASS  packages/pug/test/shadowed-block/index.test.js
 PASS  packages/pug-parser/test/no-unnecessary-blocks.test.js
 PASS  packages/pug/test/run.test.js (6.269s)

Test Suites: 26 passed, 26 total
Tests:       645 passed, 645 total
Snapshots:   326 passed, 326 total
Time:        17.901s
Ran all test suites.
```


The output of `npm run coverage`
```
> pug-monorepo@ coverage /mnt/c/temp/pug
> jest --coverage

 PASS  packages/pug-runtime/test/index.test.js
 PASS  packages/pug-attrs/test/index.test.js
 PASS  packages/pug-walk/test/index.test.js
 PASS  packages/pug-error/test/index.test.js
 PASS  packages/pug/test/error.reporting.test.js (7.176s)
 PASS  packages/pug-lexer/test/check-lexer-functions.test.js
(node:6206) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
 PASS  packages/pug/test/pug.test.js (8.206s)
 PASS  packages/pug-filters/test/filter-aliases.test.js
 PASS  packages/pug-strip-comments/test/index.test.js
 PASS  packages/pug/test/eachOf/index.test.js
 PASS  packages/pug/test/run-syntax-errors.test.js
 PASS  packages/pug-linker/test/index.test.js
 PASS  packages/pug-filters/test/index.test.js
 PASS  packages/pug-filters/test/per-filter-options-applied-to-nested-filters.test.js
 PASS  packages/pug-lexer/test/index.test.js
 PASS  packages/pug-load/test/index.test.js
 PASS  packages/pug/test/extends-not-top-level/index.test.js
 PASS  packages/pug-parser/test/index.test.js
 PASS  packages/pug/test/run-es2015.test.js
 PASS  packages/pug/test/examples.test.js
 PASS  packages/pug/test/regression-2436/index.test.js
 PASS  packages/pug/test/markdown-it/index.test.js
 PASS  packages/pug/test/duplicate-block/index.test.js
 PASS  packages/pug/test/shadowed-block/index.test.js
 PASS  packages/pug-parser/test/no-unnecessary-blocks.test.js
 PASS  packages/pug/test/run.test.js (6.768s)
------------------------------------|----------|----------|----------|----------|-------------------|
File                                |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
------------------------------------|----------|----------|----------|----------|-------------------|
All files                           |    93.91 |    89.95 |     94.8 |    95.62 |                   |
 packages/pug-attrs                 |      100 |      100 |      100 |      100 |                   |
  index.js                          |      100 |      100 |      100 |      100 |                   |
 packages/pug-code-gen              |    94.66 |    91.12 |    97.56 |    95.11 |                   |
  index.js                          |    94.66 |    91.12 |    97.56 |    95.11 |... 91,292,294,351 |
 packages/pug-error                 |    96.67 |      100 |    66.67 |    96.67 |                   |
  index.js                          |    96.67 |      100 |    66.67 |    96.67 |                40 |
 packages/pug-filters               |      100 |      100 |      100 |      100 |                   |
  index.js                          |      100 |      100 |      100 |      100 |                   |
 packages/pug-filters/lib           |    96.55 |    89.58 |      100 |    96.55 |                   |
  handle-filters.js                 |    98.44 |    92.11 |      100 |    98.44 |               102 |
  run-filter.js                     |     91.3 |       80 |      100 |     91.3 |             33,34 |
 packages/pug-filters/test          |      100 |      100 |      100 |      100 |                   |
  custom-filters.js                 |      100 |      100 |      100 |      100 |                   |
 packages/pug-lexer                 |    95.54 |    92.43 |    98.39 |    96.16 |                   |
  index.js                          |    95.54 |    92.43 |    98.39 |    96.16 |... 1488,1489,1490 |
 packages/pug-linker                |    98.15 |    97.26 |      100 |     98.1 |                   |
  index.js                          |    98.15 |    97.26 |      100 |     98.1 |            91,160 |
 packages/pug-load                  |    97.96 |    96.88 |      100 |    97.96 |                   |
  index.js                          |    97.96 |    96.88 |      100 |    97.96 |                18 |
 packages/pug-parser                |    90.93 |    84.48 |    97.73 |    92.64 |                   |
  index.js                          |    90.93 |    84.48 |    97.73 |    92.64 |... 9,990,991,1084 |
 packages/pug-parser/lib            |      100 |      100 |      100 |      100 |                   |
  inline-tags.js                    |      100 |      100 |      100 |      100 |                   |
 packages/pug-runtime               |      100 |    99.01 |      100 |      100 |                   |
  build.js                          |      100 |      100 |      100 |      100 |                   |
  index.js                          |      100 |    98.97 |      100 |      100 |               161 |
  wrap.js                           |      100 |      100 |      100 |      100 |                   |
 packages/pug-runtime/lib           |      100 |      100 |      100 |      100 |                   |
  dependencies.js                   |      100 |      100 |      100 |      100 |                   |
  internals.js                      |      100 |      100 |      100 |      100 |                   |
  sources.js                        |      100 |      100 |      100 |      100 |                   |
 packages/pug-strip-comments        |      100 |      100 |      100 |      100 |                   |
  index.js                          |      100 |      100 |      100 |      100 |                   |
 packages/pug-walk                  |    94.92 |     91.3 |      100 |    94.92 |                   |
  index.js                          |    94.92 |     91.3 |      100 |    94.92 |          25,98,99 |
 packages/pug/examples              |    98.67 |       50 |      100 |      100 |                   |
  attributes.js                     |      100 |      100 |      100 |      100 |                   |
  code.js                           |      100 |      100 |      100 |      100 |                   |
  dynamicscript.js                  |      100 |      100 |      100 |      100 |                   |
  each.js                           |      100 |      100 |      100 |      100 |                   |
  extend.js                         |      100 |      100 |      100 |      100 |                   |
  form.js                           |      100 |      100 |      100 |      100 |                   |
  includes.js                       |      100 |      100 |      100 |      100 |                   |
  layout-debug.js                   |       80 |       50 |      100 |      100 |                 9 |
  layout.js                         |      100 |      100 |      100 |      100 |                   |
  mixins.js                         |      100 |      100 |      100 |      100 |                   |
  rss.js                            |      100 |      100 |      100 |      100 |                   |
  text.js                           |      100 |      100 |      100 |      100 |                   |
  whitespace.js                     |      100 |      100 |      100 |      100 |                   |
 packages/pug/lib                   |    90.67 |    85.14 |    70.37 |    90.48 |                   |
  index.js                          |    90.67 |    85.14 |    70.37 |    90.48 |... 59,461,462,464 |
 packages/pug/test                  |    93.33 |       75 |      100 |    93.33 |                   |
  run-utils.js                      |    93.33 |       75 |      100 |    93.33 |          23,24,27 |
 packages/pug/test/temp             |    33.33 |    10.71 |       50 |      100 |                   |
  input-compileModuleFileClient.js  |    33.33 |    10.71 |       50 |      100 |             1,3,6 |
 scripts                            |      100 |      100 |      100 |      100 |                   |
  filename-serializer.js            |      100 |      100 |      100 |      100 |                   |
  prettier-javascript-serializer.js |      100 |      100 |      100 |      100 |                   |
------------------------------------|----------|----------|----------|----------|-------------------|

Test Suites: 26 passed, 26 total
Tests:       645 passed, 645 total
Snapshots:   326 passed, 326 total
Time:        21.893s
Ran all test suites.
```
