### PR TITLE
Add missing dev dependency acorn-walk in pug-lexer

### DIFF
--- a/packages/pug-lexer/package.json
+++ b/packages/pug-lexer/package.json
@@ -11,7 +11,8 @@
     "pug-error": "^1.3.3"
   },
   "devDependencies": {
-    "acorn": "^7.1.0"
+    "acorn": "^7.1.0",
+    "acorn-walk": "^7.0.0"
   },
   "files": [
     "index.js"

--- a/packages/pug-lexer/test/check-lexer-functions.test.js
+++ b/packages/pug-lexer/test/check-lexer-functions.test.js
@@ -1,6 +1,6 @@
 var fs = require('fs');
 var acorn = require('acorn');
-var walk = require('acorn/dist/walk');
+var walk = require('acorn-walk');
 
 var hadErrors = false;
 


### PR DESCRIPTION
This is to address the breaking change documented at https://github.com/acornjs/acorn/blob/master/acorn/CHANGELOG.md#breaking-changes-1

As of Acorn 6.0.0, acorn walk module has been split into a separate npm package.