### PR TITLE
Hotfix/inlcude files without ext

### DIFF
--- a/packages/pug-load/index.js
+++ b/packages/pug-load/index.js
@@ -5,7 +5,7 @@ var path = require('path');
 var walk = require('pug-walk');
 var assign = require('object-assign');
 
-function tryReadFile(options, file, node, isChangeType) {
+function tryReadFile(options, file, node) {
   var pathSrt, str;
   try {
     pathSrt = options.resolve(file.path, file.filename, options);

--- a/packages/pug-load/index.js
+++ b/packages/pug-load/index.js
@@ -5,7 +5,7 @@ var path = require('path');
 var walk = require('pug-walk');
 var assign = require('object-assign');
 
-function tryReadFile(options, file, node) {
+function tryReadFile(options, file, node, isChangeType) {
   var pathSrt, str;
   try {
     pathSrt = options.resolve(file.path, file.filename, options);
@@ -37,12 +37,16 @@ function load(ast, options) {
         try {
           readResult = tryReadFile(options, file, node);
         } catch (ex) {
-          if (path.basename(file.path, '.pug')[0] !== '.') {
+          if (!(/\.pug$/.test(file.path))) {
             throw ex;
           }
           node.type = 'RawInclude';
           node.file.path = node.file.path.slice(0, -4);
-          readResult = tryReadFile(options, file, node);
+          try {
+            readResult = tryReadFile(options, file, node, true);
+          } catch (_ex) {
+            throw ex;
+          }
         }
         pathSrt = readResult.pathSrt;
         str = readResult.str;

--- a/packages/pug-load/index.js
+++ b/packages/pug-load/index.js
@@ -37,7 +37,7 @@ function load(ast, options) {
         try {
           readResult = tryReadFile(options, file, node);
         } catch (ex) {
-          if (!(/\.pug$/.test(file.path))) {
+          if (node.type !== 'Include') {
             throw ex;
           }
           node.type = 'RawInclude';

--- a/packages/pug-parser/index.js
+++ b/packages/pug-parser/index.js
@@ -874,11 +874,11 @@ loop:
       }
     } else {
       node.type = 'RawInclude';
-      node.filters = filters;
       if (this.peek().type === 'indent') {
         this.error('RAW_INCLUDE_BLOCK', 'Raw inclusion cannot contain a block', this.peek());
       }
     }
+    node.filters = filters;
     return node;
   },
 


### PR DESCRIPTION
Hello everyone here!

I am trying to solve the problem I found with including files without extension as raw https://github.com/pugjs/pug/issues/3116 .

The error occurs at the parsing stage ( https://github.com/pugjs/pug/blob/master/packages/pug/lib/index.js#L104 ), when `path.extname(token.val)` says that the file has no extension, so pug add `.pug` extension to the file.

This is true for most cases, but false for files without an extension.

The only way to fix this at the parsing stage is to check for a file on the file system. But I think it will be too difficult operation for the parsing stage. Therefore, I tried to solve the problem on the other hand, at the stage of reading the file.

If we determine that the file with the type `Include` could not be read, we try to change its type to `RawInclude`, delete the extension and read it again.

Since the type was initially defined as `Include`, and the type `RawInclude` requires `filters` field in `node`, I tried to assign filters always, regardless of the type. I did not understand the meaning of these filters and am not sure if this is the right solution. Perhaps it would be more correct to assign an empty array instead of filters at the time of type change.

If such a solution is acceptable at all, there is an open question:

Should I assign filters to a node regardless of its type and add corrections for tests? Or should I assign an empty array as filter at the time the node type changes?
