### PR TITLE
Add the possibility of replacing generateCode function

### DIFF
--- a/packages/pug/lib/index.js
+++ b/packages/pug/lib/index.js
@@ -171,12 +171,8 @@ function compileBody(str, options){
   ast = applyPlugins(ast, options, plugins, 'postLink');
 
   // Compile
-  var generateCodeReplacement = findReplacementFunc(plugins, 'generateCode');
-  if (generateCodeReplacement) {
-    generateCode = generateCodeReplacement;
-  }
   ast = applyPlugins(ast, options, plugins, 'preCodeGen');
-  var js = generateCode(ast, {
+  var js = (findReplacementFunc(plugins, 'generateCode') || generateCode)(ast, {
     pretty: options.pretty,
     compileDebug: options.compileDebug,
     doctype: options.doctype,

--- a/packages/pug/lib/index.js
+++ b/packages/pug/lib/index.js
@@ -171,7 +171,7 @@ function compileBody(str, options){
   ast = applyPlugins(ast, options, plugins, 'postLink');
 
   // Compile
-  var generateCodeReplacement = findReplacementFunc(plugins, 'generateCode')
+  var generateCodeReplacement = findReplacementFunc(plugins, 'generateCode');
   if (generateCodeReplacement) {
     generateCode = generateCodeReplacement;
   }

--- a/packages/pug/lib/index.js
+++ b/packages/pug/lib/index.js
@@ -171,6 +171,10 @@ function compileBody(str, options){
   ast = applyPlugins(ast, options, plugins, 'postLink');
 
   // Compile
+  var generateCodeReplacement = findReplacementFunc(plugins, 'generateCode')
+  if (generateCodeReplacement) {
+    generateCode = generateCodeReplacement;
+  }
   ast = applyPlugins(ast, options, plugins, 'preCodeGen');
   var js = generateCode(ast, {
     pretty: options.pretty,


### PR DESCRIPTION
Hi! I'm trying to solve some issues in pug-loader, but in order to do that I need to forbid removing all unused mixins during the compilation. Instead of littering the "pug" interface with specific options, I decided that the better solution was allowing developers to override generateCode function. I believe that It might be useful in some other cases as well.