### PR TITLE
Properly handle errors originating from included files when compileDebug is enabled

### DIFF
--- a/packages/pug-runtime/index.js
+++ b/packages/pug-runtime/index.js
@@ -247,18 +247,24 @@ function pug_rethrow(err, filename, lineno, str) {
     err.message += ' on line ' + lineno;
     throw err;
   }
+  var context, lines, start, end;
   try {
-    str = str || require('fs').readFileSync(filename, 'utf8');
+    var encoding = 'utf8';
+    str = str || require('fs').readFileSync(filename, {encoding: encoding});
+    if (str.type === 'Buffer') {
+      str = Buffer.from(str.data).toString(encoding);
+    }
+    context = 3;
+    lines = str.split('\n');
+    start = Math.max(lineno - context, 0);
+    end = Math.min(lines.length, lineno + context);
   } catch (ex) {
     pug_rethrow(err, null, lineno);
+    return;
   }
-  var context = 3,
-    lines = str.split('\n'),
-    start = Math.max(lineno - context, 0),
-    end = Math.min(lines.length, lineno + context);
 
   // Error context
-  var context = lines
+  context = lines
     .slice(start, end)
     .map(function(line, i) {
       var curr = i + start + 1;

--- a/packages/pug-runtime/index.js
+++ b/packages/pug-runtime/index.js
@@ -249,16 +249,14 @@ function pug_rethrow(err, filename, lineno, str) {
   }
   var context, lines, start, end;
   try {
-    var encoding = 'utf8';
-    str = str || require('fs').readFileSync(filename, {encoding: encoding});
-    if (str.type === 'Buffer') {
-      str = Buffer.from(str.data).toString(encoding);
-    }
+    str = str || require('fs').readFileSync(filename, {encoding: 'utf8'});
     context = 3;
     lines = str.split('\n');
     start = Math.max(lineno - context, 0);
     end = Math.min(lines.length, lineno + context);
   } catch (ex) {
+    err.message +=
+      ' - could not read from ' + filename + ' (' + ex.message + ')';
     pug_rethrow(err, null, lineno);
     return;
   }

--- a/packages/pug-runtime/test/index.test.js
+++ b/packages/pug-runtime/test/index.test.js
@@ -252,17 +252,15 @@ foo.pug:3
     throw new Error('expected rethrow to throw');
   });
 
-  it("should rethrow error with toJSON()'d Buffer", () => {
-    const err = new Error();
-    const str = Buffer.from('hello world').toJSON();
+  it('should handle bad arguments gracefully', () => {
+    const err = new Error('hello world');
+    const str = {not: 'a string'};
     try {
       runtime.rethrow(err, 'foo.pug', 3, str);
     } catch (e) {
       expect(e).toBe(err);
-      expect(e.message.trim()).toBe(
-        `
-foo.pug:3
-    1| hello world`.trim()
+      expect(e.message).toBe(
+        'hello world - could not read from foo.pug (str.split is not a function) on line 3'
       );
       return;
     }

--- a/packages/pug-runtime/test/index.test.js
+++ b/packages/pug-runtime/test/index.test.js
@@ -221,3 +221,52 @@ addTest('style', function(style) {
   expect(style({foo: 'bar'})).toBe('foo:bar;');
   expect(style({foo: 'bar', baz: 'bash'})).toBe('foo:bar;baz:bash;');
 });
+
+describe('rethrow', () => {
+  it('should rethrow error', () => {
+    const err = new Error();
+    try {
+      runtime.rethrow(err, 'foo.pug', 3);
+    } catch (e) {
+      expect(e).toBe(err);
+      return;
+    }
+
+    throw new Error('expected rethrow to throw');
+  });
+
+  it('should rethrow error with str', () => {
+    const err = new Error();
+    try {
+      runtime.rethrow(err, 'foo.pug', 3, 'hello world');
+    } catch (e) {
+      expect(e).toBe(err);
+      expect(e.message.trim()).toBe(
+        `
+foo.pug:3
+    1| hello world`.trim()
+      );
+      return;
+    }
+
+    throw new Error('expected rethrow to throw');
+  });
+
+  it("should rethrow error with toJSON()'d Buffer", () => {
+    const err = new Error();
+    const str = Buffer.from('hello world').toJSON();
+    try {
+      runtime.rethrow(err, 'foo.pug', 3, str);
+    } catch (e) {
+      expect(e).toBe(err);
+      expect(e.message.trim()).toBe(
+        `
+foo.pug:3
+    1| hello world`.trim()
+      );
+      return;
+    }
+
+    throw new Error('expected rethrow to throw');
+  });
+});

--- a/packages/pug/lib/index.js
+++ b/packages/pug/lib/index.js
@@ -164,7 +164,9 @@ function compileBody(str, options) {
         contents = load.read(filename, loadOptions);
       }
 
-      debug_sources[filename] = contents;
+      debug_sources[filename] = Buffer.isBuffer(contents)
+        ? contents.toString('utf8')
+        : contents;
       return contents;
     },
   });

--- a/packages/pug/test/__snapshots__/pug.test.js.snap
+++ b/packages/pug/test/__snapshots__/pug.test.js.snap
@@ -56,33 +56,35 @@ exports[`pug .compileClient() should support module syntax in pug.compileClient(
   return c !== r ? s + a.substring(c, r) : s;
 }
 var pug_match_html = /[\\"&<>]/;
-function pug_rethrow(n, t, e, r) {
-  if (!(n instanceof Error)) throw n;
-  if (!((\\"undefined\\" == typeof window && t) || r))
-    throw ((n.message += \\" on line \\" + e), n);
-  var i, o, a, f;
+function pug_rethrow(e, n, r, t) {
+  if (!(e instanceof Error)) throw e;
+  if (!((\\"undefined\\" == typeof window && n) || t))
+    throw ((e.message += \\" on line \\" + r), e);
+  var o, a, i, s;
   try {
-    (r = r || require(\\"fs\\").readFileSync(t, { encoding: \\"utf8\\" })),
-      \\"Buffer\\" === r.type && (r = Buffer.from(r.data).toString(\\"utf8\\")),
-      (i = 3),
-      (o = r.split(\\"\\\\n\\")),
-      (a = Math.max(e - i, 0)),
-      (f = Math.min(o.length, e + i));
+    (t = t || require(\\"fs\\").readFileSync(n, { encoding: \\"utf8\\" })),
+      (o = 3),
+      (a = t.split(\\"\\\\n\\")),
+      (i = Math.max(r - o, 0)),
+      (s = Math.min(a.length, r + o));
   } catch (t) {
-    return void pug_rethrow(n, null, e);
+    return (
+      (e.message += \\" - could not read from \\" + n + \\" (\\" + t.message + \\")\\"),
+      void pug_rethrow(e, null, r)
+    );
   }
-  (i = o
-    .slice(a, f)
-    .map(function(n, t) {
-      var r = t + a + 1;
-      return (r == e ? \\"  > \\" : \\"    \\") + r + \\"| \\" + n;
+  (o = a
+    .slice(i, s)
+    .map(function(e, n) {
+      var t = n + i + 1;
+      return (t == r ? \\"  > \\" : \\"    \\") + t + \\"| \\" + e;
     })
     .join(\\"\\\\n\\")),
-    (n.path = t);
+    (e.path = n);
   try {
-    n.message = (t || \\"Pug\\") + \\":\\" + e + \\"\\\\n\\" + i + \\"\\\\n\\\\n\\" + n.message;
-  } catch (n) {}
-  throw n;
+    e.message = (n || \\"Pug\\") + \\":\\" + r + \\"\\\\n\\" + o + \\"\\\\n\\\\n\\" + e.message;
+  } catch (e) {}
+  throw e;
 }
 function template(locals) {
   var pug_html = \\"\\",

--- a/packages/pug/test/__snapshots__/pug.test.js.snap
+++ b/packages/pug/test/__snapshots__/pug.test.js.snap
@@ -56,29 +56,31 @@ exports[`pug .compileClient() should support module syntax in pug.compileClient(
   return c !== r ? s + a.substring(c, r) : s;
 }
 var pug_match_html = /[\\"&<>]/;
-function pug_rethrow(n, e, t, r) {
+function pug_rethrow(n, t, e, r) {
   if (!(n instanceof Error)) throw n;
-  if (!((\\"undefined\\" == typeof window && e) || r))
-    throw ((n.message += \\" on line \\" + t), n);
+  if (!((\\"undefined\\" == typeof window && t) || r))
+    throw ((n.message += \\" on line \\" + e), n);
+  var i, o, a, f;
   try {
-    r = r || require(\\"fs\\").readFileSync(e, \\"utf8\\");
-  } catch (e) {
-    pug_rethrow(n, null, t);
+    (r = r || require(\\"fs\\").readFileSync(t, { encoding: \\"utf8\\" })),
+      \\"Buffer\\" === r.type && (r = Buffer.from(r.data).toString(\\"utf8\\")),
+      (i = 3),
+      (o = r.split(\\"\\\\n\\")),
+      (a = Math.max(e - i, 0)),
+      (f = Math.min(o.length, e + i));
+  } catch (t) {
+    return void pug_rethrow(n, null, e);
   }
-  var a = 3,
-    i = r.split(\\"\\\\n\\"),
-    o = Math.max(t - a, 0),
-    h = Math.min(i.length, t + a),
-    a = i
-      .slice(o, h)
-      .map(function(n, e) {
-        var r = e + o + 1;
-        return (r == t ? \\"  > \\" : \\"    \\") + r + \\"| \\" + n;
-      })
-      .join(\\"\\\\n\\");
-  n.path = e;
+  (i = o
+    .slice(a, f)
+    .map(function(n, t) {
+      var r = t + a + 1;
+      return (r == e ? \\"  > \\" : \\"    \\") + r + \\"| \\" + n;
+    })
+    .join(\\"\\\\n\\")),
+    (n.path = t);
   try {
-    n.message = (e || \\"Pug\\") + \\":\\" + t + \\"\\\\n\\" + a + \\"\\\\n\\\\n\\" + n.message;
+    n.message = (t || \\"Pug\\") + \\":\\" + e + \\"\\\\n\\" + i + \\"\\\\n\\\\n\\" + n.message;
   } catch (n) {}
   throw n;
 }

--- a/packages/pug/test/error.reporting.test.js
+++ b/packages/pug/test/error.reporting.test.js
@@ -80,7 +80,19 @@ describe('error reporting', function() {
         expect(err.message).toMatch(/[\\\/]include.locals.error.pug:2/);
         expect(err.message).toMatch(/foo\(/);
       });
+
+      it('handles compileDebug option properly', function() {
+        var err = getFileError(
+          __dirname + '/fixtures/compile.with.include.locals.error.pug',
+          {
+            compileDebug: true,
+          }
+        );
+        expect(err.message).toMatch(/[\\\/]include.locals.error.pug:2/);
+        expect(err.message).toMatch(/foo is not a function/);
+      });
     });
+
     describe('with a layout (without block) with an include (syntax)', function() {
       it('includes detail of where the error was thrown including the filename', function() {
         var err = getFileError(

--- a/packages/pug/test/pug.test.js
+++ b/packages/pug/test/pug.test.js
@@ -1243,7 +1243,6 @@ describe('pug', function() {
         __dirname + '/temp/input-compileModuleFileClient.js',
         fn
       );
-      var expected = '<div class="bar">baz</div>';
       var fn = require(__dirname + '/temp/input-compileModuleFileClient.js');
       expect(fn({foo: 'baz'})).toBe('<div class="bar">baz</div>');
     });


### PR DESCRIPTION
When calling render/compile with `{ compileDebug: true }`, and an error was thrown from (or due to) a local, the `str` parameter in `pug_rethrow` was a `toJSON()`'d `Buffer`, and the rethrow code tried to `split` it like a string.

`str` would be something like:
```javascript
{
  type: 'Buffer',
  data: [ /* a bunch of numbers */ ]
}
```

which is what happens when you do something like `Buffer.from('foo').toJSON()`.

I couldn't really figure out where or how it happens, but I just made the rethrow function gracefully handle those serialized `Buffer` objects properly.

I wrote a test that failed (basically just calls an undefined function from an included file):
![pug-error-reporting](https://user-images.githubusercontent.com/188562/85069254-aae3ea80-b168-11ea-865d-00623c42b4ef.png)

and then fixed it in this PR.
