### PR TITLE
fix capture groups for "each" statements

### DIFF
--- a/packages/pug-lexer/index.js
+++ b/packages/pug-lexer/index.js
@@ -1082,7 +1082,7 @@ Lexer.prototype = {
 
   eachOf: function() {
     var captures;
-    if ((captures = /^(?:each|for) (.*) of *([^\n]+)/.exec(this.input))) {
+    if ((captures = /^(?:each|for) (.*?) of *([^\n]+)/.exec(this.input))) {
       this.consume(captures[0].length);
       var tok = this.tok('eachOf', captures[1]);
       tok.value = captures[1];

--- a/packages/pug-lexer/test/__snapshots__/index.test.js.snap
+++ b/packages/pug-lexer/test/__snapshots__/index.test.js.snap
@@ -15468,12 +15468,12 @@ Array [
     "loc": Object {
       "end": Object {
         "column": 1,
-        "line": 44,
+        "line": 45,
       },
       "filename": "<basedir>/packages/pug-lexer/test/cases/each.else.pug",
       "start": Object {
         "column": 1,
-        "line": 44,
+        "line": 45,
       },
     },
     "type": "outdent",
@@ -15482,12 +15482,151 @@ Array [
     "loc": Object {
       "end": Object {
         "column": 1,
-        "line": 44,
+        "line": 45,
       },
       "filename": "<basedir>/packages/pug-lexer/test/cases/each.else.pug",
       "start": Object {
         "column": 1,
-        "line": 44,
+        "line": 45,
+      },
+    },
+    "type": "outdent",
+  },
+  Object {
+    "buffer": false,
+    "loc": Object {
+      "end": Object {
+        "column": 74,
+        "line": 45,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/each.else.pug",
+      "start": Object {
+        "column": 1,
+        "line": 45,
+      },
+    },
+    "mustEscape": false,
+    "type": "code",
+    "val": "var ofKeyword = [{ name: 'tobi', friends: ['loki'] }, { name: 'loki' }]",
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 1,
+        "line": 46,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/each.else.pug",
+      "start": Object {
+        "column": 1,
+        "line": 46,
+      },
+    },
+    "type": "newline",
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 3,
+        "line": 46,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/each.else.pug",
+      "start": Object {
+        "column": 1,
+        "line": 46,
+      },
+    },
+    "type": "tag",
+    "val": "ul",
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 3,
+        "line": 47,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/each.else.pug",
+      "start": Object {
+        "column": 1,
+        "line": 47,
+      },
+    },
+    "type": "indent",
+    "val": 2,
+  },
+  Object {
+    "code": "ofKeyword",
+    "loc": Object {
+      "end": Object {
+        "column": 24,
+        "line": 47,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/each.else.pug",
+      "start": Object {
+        "column": 3,
+        "line": 47,
+      },
+    },
+    "type": "eachOf",
+    "val": "val",
+    "value": "val",
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 5,
+        "line": 48,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/each.else.pug",
+      "start": Object {
+        "column": 1,
+        "line": 48,
+      },
+    },
+    "type": "indent",
+    "val": 4,
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 7,
+        "line": 48,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/each.else.pug",
+      "start": Object {
+        "column": 5,
+        "line": 48,
+      },
+    },
+    "type": "tag",
+    "val": "li",
+  },
+  Object {
+    "buffer": true,
+    "loc": Object {
+      "end": Object {
+        "column": 18,
+        "line": 48,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/each.else.pug",
+      "start": Object {
+        "column": 7,
+        "line": 48,
+      },
+    },
+    "mustEscape": true,
+    "type": "code",
+    "val": "user.name",
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 1,
+        "line": 50,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/each.else.pug",
+      "start": Object {
+        "column": 1,
+        "line": 50,
       },
     },
     "type": "outdent",
@@ -15496,12 +15635,148 @@ Array [
     "loc": Object {
       "end": Object {
         "column": 1,
-        "line": 44,
+        "line": 50,
       },
       "filename": "<basedir>/packages/pug-lexer/test/cases/each.else.pug",
       "start": Object {
         "column": 1,
-        "line": 44,
+        "line": 50,
+      },
+    },
+    "type": "outdent",
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 3,
+        "line": 50,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/each.else.pug",
+      "start": Object {
+        "column": 1,
+        "line": 50,
+      },
+    },
+    "type": "tag",
+    "val": "ul",
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 3,
+        "line": 51,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/each.else.pug",
+      "start": Object {
+        "column": 1,
+        "line": 51,
+      },
+    },
+    "type": "indent",
+    "val": 2,
+  },
+  Object {
+    "code": "[\\"variable with of keyword\\"]",
+    "loc": Object {
+      "end": Object {
+        "column": 43,
+        "line": 51,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/each.else.pug",
+      "start": Object {
+        "column": 3,
+        "line": 51,
+      },
+    },
+    "type": "eachOf",
+    "val": "val",
+    "value": "val",
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 5,
+        "line": 52,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/each.else.pug",
+      "start": Object {
+        "column": 1,
+        "line": 52,
+      },
+    },
+    "type": "indent",
+    "val": 4,
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 7,
+        "line": 52,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/each.else.pug",
+      "start": Object {
+        "column": 5,
+        "line": 52,
+      },
+    },
+    "type": "tag",
+    "val": "li",
+  },
+  Object {
+    "buffer": true,
+    "loc": Object {
+      "end": Object {
+        "column": 12,
+        "line": 52,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/each.else.pug",
+      "start": Object {
+        "column": 7,
+        "line": 52,
+      },
+    },
+    "mustEscape": true,
+    "type": "code",
+    "val": "val",
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 12,
+        "line": 52,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/each.else.pug",
+      "start": Object {
+        "column": 12,
+        "line": 52,
+      },
+    },
+    "type": "outdent",
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 12,
+        "line": 52,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/each.else.pug",
+      "start": Object {
+        "column": 12,
+        "line": 52,
+      },
+    },
+    "type": "outdent",
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 12,
+        "line": 52,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/each.else.pug",
+      "start": Object {
+        "column": 12,
+        "line": 52,
       },
     },
     "type": "eos",

--- a/packages/pug-lexer/test/cases/each.else.pug
+++ b/packages/pug-lexer/test/cases/each.else.pug
@@ -41,3 +41,12 @@ ul
     li #{key}: #{val}
   else
     li user has no details!
+
+- var ofKeyword = [{ name: 'tobi', friends: ['loki'] }, { name: 'loki' }]
+ul
+  each val of ofKeyword
+    li= user.name
+
+ul
+  each val of ["variable with of keyword"]
+    li= val


### PR DESCRIPTION
Variables starting with `of` cause the regex to "drift" on capture groups

## Example

```
each item of offers
  i= item
```
This causes

```
The value variable for each must either be a valid identifier (e.g. `item`) or a
pair of identifiers in square brackets (e.g. `[key, value]`).
```

## Cause

The non-greedy `(.*)` matches the `of` of the variable for the `of` statement. This causes matching group misalignment, which leads to the displayed error.

## Workaround

Rename your variable to something not starting with `of` :blush: 


---

fixes #3263
fixes #3275