### PR TITLE
fix: Fix pug-lexer parsed escaped interpolations incorrectly

### DIFF
--- a/packages/pug-lexer/index.js
+++ b/packages/pug-lexer/index.js
@@ -579,7 +579,7 @@ Lexer.prototype = {
     }
     if (indexOfStringInterp !== Infinity) {
       if (matchOfStringInterp[1]) {
-        prefix = prefix + value.substring(0, indexOfStringInterp) + '#{';
+        prefix = prefix + value.substring(0, indexOfStringInterp) + matchOfStringInterp[2] + '{';
         return this.addText(
           type,
           value.substring(indexOfStringInterp + 3),

--- a/packages/pug-lexer/index.js
+++ b/packages/pug-lexer/index.js
@@ -579,7 +579,11 @@ Lexer.prototype = {
     }
     if (indexOfStringInterp !== Infinity) {
       if (matchOfStringInterp[1]) {
-        prefix = prefix + value.substring(0, indexOfStringInterp) + matchOfStringInterp[2] + '{';
+        prefix =
+          prefix +
+          value.substring(0, indexOfStringInterp) +
+          matchOfStringInterp[2] +
+          '{';
         return this.addText(
           type,
           value.substring(indexOfStringInterp + 3),

--- a/packages/pug-lexer/test/__snapshots__/index.test.js.snap
+++ b/packages/pug-lexer/test/__snapshots__/index.test.js.snap
@@ -26703,30 +26703,16 @@ Array [
 exports[`interpolation.escape.pug 1`] = `
 Array [
   Object {
-    "loc": Object {
-      "end": Object {
-        "column": 1,
-        "line": 2,
-      },
-      "filename": "<basedir>/packages/pug-lexer/test/cases/interpolation.escape.pug",
-      "start": Object {
-        "column": 1,
-        "line": 2,
-      },
-    },
-    "type": "newline",
-  },
-  Object {
     "buffer": false,
     "loc": Object {
       "end": Object {
         "column": 15,
-        "line": 2,
+        "line": 1,
       },
       "filename": "<basedir>/packages/pug-lexer/test/cases/interpolation.escape.pug",
       "start": Object {
         "column": 1,
-        "line": 2,
+        "line": 1,
       },
     },
     "mustEscape": false,
@@ -26737,12 +26723,12 @@ Array [
     "loc": Object {
       "end": Object {
         "column": 1,
-        "line": 3,
+        "line": 2,
       },
       "filename": "<basedir>/packages/pug-lexer/test/cases/interpolation.escape.pug",
       "start": Object {
         "column": 1,
-        "line": 3,
+        "line": 2,
       },
     },
     "type": "newline",
@@ -26751,6 +26737,21 @@ Array [
     "loc": Object {
       "end": Object {
         "column": 4,
+        "line": 2,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/interpolation.escape.pug",
+      "start": Object {
+        "column": 1,
+        "line": 2,
+      },
+    },
+    "type": "tag",
+    "val": "foo",
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 3,
         "line": 3,
       },
       "filename": "<basedir>/packages/pug-lexer/test/cases/interpolation.escape.pug",
@@ -26759,8 +26760,23 @@ Array [
         "line": 3,
       },
     },
-    "type": "tag",
-    "val": "foo",
+    "type": "indent",
+    "val": 2,
+  },
+  Object {
+    "loc": Object {
+      "end": Object {
+        "column": 9,
+        "line": 3,
+      },
+      "filename": "<basedir>/packages/pug-lexer/test/cases/interpolation.escape.pug",
+      "start": Object {
+        "column": 5,
+        "line": 3,
+      },
+    },
+    "type": "text",
+    "val": "some",
   },
   Object {
     "loc": Object {
@@ -26774,13 +26790,12 @@ Array [
         "line": 4,
       },
     },
-    "type": "indent",
-    "val": 2,
+    "type": "newline",
   },
   Object {
     "loc": Object {
       "end": Object {
-        "column": 9,
+        "column": 13,
         "line": 4,
       },
       "filename": "<basedir>/packages/pug-lexer/test/cases/interpolation.escape.pug",
@@ -26790,7 +26805,7 @@ Array [
       },
     },
     "type": "text",
-    "val": "some",
+    "val": "#{text}",
   },
   Object {
     "loc": Object {
@@ -26819,7 +26834,7 @@ Array [
       },
     },
     "type": "text",
-    "val": "#{text}",
+    "val": "!{here}",
   },
   Object {
     "loc": Object {
@@ -26831,35 +26846,6 @@ Array [
       "start": Object {
         "column": 1,
         "line": 6,
-      },
-    },
-    "type": "newline",
-  },
-  Object {
-    "loc": Object {
-      "end": Object {
-        "column": 9,
-        "line": 6,
-      },
-      "filename": "<basedir>/packages/pug-lexer/test/cases/interpolation.escape.pug",
-      "start": Object {
-        "column": 5,
-        "line": 6,
-      },
-    },
-    "type": "text",
-    "val": "here",
-  },
-  Object {
-    "loc": Object {
-      "end": Object {
-        "column": 3,
-        "line": 7,
-      },
-      "filename": "<basedir>/packages/pug-lexer/test/cases/interpolation.escape.pug",
-      "start": Object {
-        "column": 1,
-        "line": 7,
       },
     },
     "type": "newline",
@@ -26868,12 +26854,12 @@ Array [
     "loc": Object {
       "end": Object {
         "column": 11,
-        "line": 7,
+        "line": 6,
       },
       "filename": "<basedir>/packages/pug-lexer/test/cases/interpolation.escape.pug",
       "start": Object {
         "column": 5,
-        "line": 7,
+        "line": 6,
       },
     },
     "type": "text",
@@ -26884,12 +26870,12 @@ Array [
     "loc": Object {
       "end": Object {
         "column": 31,
-        "line": 7,
+        "line": 6,
       },
       "filename": "<basedir>/packages/pug-lexer/test/cases/interpolation.escape.pug",
       "start": Object {
         "column": 11,
-        "line": 7,
+        "line": 6,
       },
     },
     "mustEscape": true,
@@ -26899,12 +26885,12 @@ Array [
   Object {
     "loc": Object {
       "end": Object {
-        "column": 31,
+        "column": 1,
         "line": 7,
       },
       "filename": "<basedir>/packages/pug-lexer/test/cases/interpolation.escape.pug",
       "start": Object {
-        "column": 31,
+        "column": 1,
         "line": 7,
       },
     },
@@ -26913,12 +26899,12 @@ Array [
   Object {
     "loc": Object {
       "end": Object {
-        "column": 31,
+        "column": 1,
         "line": 7,
       },
       "filename": "<basedir>/packages/pug-lexer/test/cases/interpolation.escape.pug",
       "start": Object {
-        "column": 31,
+        "column": 1,
         "line": 7,
       },
     },

--- a/packages/pug-lexer/test/cases/interpolation.escape.pug
+++ b/packages/pug-lexer/test/cases/interpolation.escape.pug
@@ -1,7 +1,6 @@
-
 - var id = 42;
 foo
   | some
   | \#{text}
-  | here
+  | \!{here}
   | My ID #{"is {" + id + "}"}


### PR DESCRIPTION
Pug-lexer always parsed escaped interpolations (`\#{...}` and `\!{...}`) into `#{...}`.

Here's the sample: https://runkit.com/shirohana/5f99255fb3cdb4001a711cf9

```js
const { Lexer } = require('pug-lexer')

const code = `
p \\#{value}
p \\!{value}
`
const lexer = new Lexer(code, { filename: 'index.pug' })
const tokens = lexer.getTokens()
```

```js
// Passed
assert(
  tokens[2].val === '#{value}',
  `1. expect "#{value}", actual: "${tokens[2].val}"`
)

// Throws
assert(
  tokens[5].val === '!{value}',
  `2. expect "!{value}", actual: "${tokens[5].val}"`
)
```