### PR TITLE
chore: update character-parser

### DIFF
--- a/packages/pug-lexer/index.js
+++ b/packages/pug-lexer/index.js
@@ -100,7 +100,7 @@ Lexer.prototype = {
   assertNestingCorrect: function(exp) {
     //this verifies that code is properly nested, but allows
     //invalid JavaScript such as the contents of `attributes`
-    var res = characterParser(exp);
+    var res = characterParser.default(exp);
     if (res.isNesting()) {
       this.error(
         'INCORRECT_NESTING',
@@ -249,7 +249,7 @@ Lexer.prototype = {
       start === '(' || start === '{' || start === '[',
       'The start character should be "(", "{" or "["'
     );
-    var end = characterParser.BRACKETS[start];
+    var end = {'(': ')', '{': '}', '[': ']'}[start];
     var range;
     try {
       range = characterParser.parseUntil(this.input, end, {start: skip + 1});
@@ -873,7 +873,7 @@ Lexer.prototype = {
   when: function() {
     var tok = this.scanEndOfLine(/^when +([^:\n]+)/, 'when');
     if (tok) {
-      var parser = characterParser(tok.val);
+      var parser = characterParser.default(tok.val);
       while (parser.isNesting() || parser.isString()) {
         var rest = /:([^:\n]+)/.exec(this.input);
         if (!rest) break;
@@ -881,7 +881,7 @@ Lexer.prototype = {
         tok.val += rest[0];
         this.consume(rest[0].length);
         this.incrementColumn(rest[0].length);
-        parser = characterParser(tok.val);
+        parser = characterParser.default(tok.val);
       }
 
       this.incrementColumn(-tok.val.length);

--- a/packages/pug-lexer/package.json
+++ b/packages/pug-lexer/package.json
@@ -6,7 +6,7 @@
     "pug"
   ],
   "dependencies": {
-    "character-parser": "^2.2.0",
+    "character-parser": "^4.0.0",
     "is-expression": "^4.0.0",
     "pug-error": "^1.3.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -998,12 +998,10 @@ char-regex@^1.0.2:
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
 
-character-parser@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/character-parser/-/character-parser-2.2.0.tgz#c7ce28f36d4bcd9744e5ffc2c5fcde1c73261fc0"
-  integrity sha1-x84o821LzZdE5f/CxfzeHHMmH8A=
-  dependencies:
-    is-regex "^1.0.3"
+character-parser@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/character-parser/-/character-parser-4.0.0.tgz#fb6899d41279880c20f1bfa31c9c7c51662744cd"
+  integrity sha512-jWburCrDpd+aPopB7esjh/gLyZoHZS4C2xwwJlkTPyhhJdXG+FCG0P4qCOInvOd9yhiuAEJYlZsUMQ0JSK4ykw==
 
 ci-info@^2.0.0:
   version "2.0.0"
@@ -1611,11 +1609,6 @@ fsevents@^2.1.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
   integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
 
-function-bind@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
-  integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
-
 gensync@^1.0.0-beta.1:
   version "1.0.0-beta.1"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.1.tgz#58f4361ff987e5ff6e1e7a210827aa371eaac269"
@@ -1755,13 +1748,6 @@ has-values@^1.0.0:
   dependencies:
     is-number "^3.0.0"
     kind-of "^4.0.0"
-
-has@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
-  integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
-  dependencies:
-    function-bind "^1.1.1"
 
 hawk@~3.1.3:
   version "3.1.3"
@@ -2004,13 +1990,6 @@ is-promise@^2.0.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.2.2.tgz#39ab959ccbf9a774cf079f7b40c7a26f763135f1"
   integrity sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==
-
-is-regex@^1.0.3:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.5.tgz#39d589a358bf18967f726967120b8fc1aed74eae"
-  integrity sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==
-  dependencies:
-    has "^1.0.3"
 
 is-stream@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
The updated dependency is written in TypeScript, which will help prepare us for converting pug-lexer to TypeScript