### PR TITLE
Add `funding` key to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,16 @@
     "type": "git",
     "url": "https://github.com/pugjs/pug.git"
   },
+  "funding": [
+    {
+      "type": "opencollective",
+      "url": "https://opencollective.com/pug"
+    },
+    {
+      "type": "tidelift",
+      "url": "https://tidelift.com/funding/github/npm/pug"
+    }
+  ],
   "scripts": {
     "prettier:check": "prettier --ignore-path .gitignore --list-different './**/*.js'",
     "format": "prettier --ignore-path .gitignore --write './**/*.js'",


### PR DESCRIPTION
Hi! I'm submitting this PR because in the [simple-icons](https://github.com/simple-icons/simple-icons) project we are trying to automate as much as possible our monetary contributions to our direct dependencies, so having this metadata in the package.json files allows us to programmatically know easily how we can fund them. See [package-json#funding](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#funding).

Cheers!