### PR TITLE
[pug-lexer] Tailwind classes support

### DIFF
--- a/packages/pug-lexer/index.js
+++ b/packages/pug-lexer/index.js
@@ -463,7 +463,7 @@ Lexer.prototype = {
    */
 
   className: function() {
-    var tok = this.scan(/^\.([_a-z0-9\-]*[_a-z][_a-z0-9\-]*)/i, 'class');
+    var tok = this.scan(/^\.([_a-z0-9\-]*[_a-z]([_a-z0-9\-\[\]]|:(?! ))*)/i, 'class');
     if (tok) {
       this.tokens.push(tok);
       this.incrementColumn(tok.val.length);

--- a/packages/pug-lexer/test/cases/classes.pug
+++ b/packages/pug-lexer/test/cases/classes.pug
@@ -12,3 +12,5 @@ a(class={foo: true, bar: false, baz: true})
 
 a.-foo
 a.3foo
+
+a.focus:border.lg:w-[555px]


### PR DESCRIPTION
Support for Tailwind classes syntax like `.lg:w-[555px]`, `.hover:border` etc
Test added

The only confilct I saw: colon `:` is used for block expansion, but only with space symbol between a blocks, Tailwind no need spaces in class names, so i just add negative lookahead for colon-space combination in regexp