### PR TITLE
Removed irrelevant info from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,18 +37,6 @@ pug-strip-comments | [![NPM version](https://img.shields.io/npm/v/pug-strip-comm
 pug-walk | [![NPM version](https://img.shields.io/npm/v/pug-walk?style=for-the-badge)](https://www.npmjs.com/package/pug-walk)
 <!-- VERSION_TABLE -->
 
-## Rename from "Jade"
-
-This project was formerly known as "Jade". However, it was revealed to us that "Jade" is a registered trademark; as a result, a rename was needed. After some discussion among the maintainers, **"Pug"** was chosen as the new name for this project. As of version 2, "pug" is the official package name.
-
-If your package or app currently uses `jade`, don't worry: we have secured permissions to continue to occupy that package name, although all new versions will be released under `pug`.
-
-Before the renaming, work had already begun on “Jade 2.0.0”. Therefore, the rename to Pug coincided with the major version bump. As a result, upgrading from Jade to Pug will be the same process as upgrading any other package with a major version bump.
-
-The syntax of Pug has several differences, deprecations, and removals compared to its predecessor. These differences are documented in [#2305](https://github.com/pugjs/pug/issues/2305).
-
-The website and documentation for Pug are still being updated. But if you are new to Pug, you should get started with the new syntax and install the Pug package from npm.
-
 ## Installation
 
 ### Package


### PR DESCRIPTION
When I first saw the readme page I thought it was showing me the wrong version of Pug, I really thought I was looking at the first beta v2 from 2016 accidentally but then I realized that, no, I was looking at the current readme page but it just contains outdated info.

To improve the experience for new users I think info about Pug being called Jade seven years ago and info about the beta v2 should be removed from the readme or at least not be the very first thing on the readme. That info is irrelevant to 99% of users. Most new users will use the latest version of Pug, v3.0.2, and they don't need to know or care that Pug was formerly known as Jade in 2016.