### PR TITLE
Added more checks

### DIFF
--- a/packages/pug-code-gen/index.js
+++ b/packages/pug-code-gen/index.js
@@ -318,7 +318,7 @@ Compiler.prototype = {
     if (debug && node.debug !== false && node.type !== 'Block') {
       if (typeof node.line !== 'number') {
         throw new Error(
-          'node.line is not a valid number. Possible prototype polution?'
+          'node.line is not a valid number.'
         );
       }
       

--- a/packages/pug-code-gen/index.js
+++ b/packages/pug-code-gen/index.js
@@ -316,7 +316,7 @@ Compiler.prototype = {
     }
 
     if (debug && node.debug !== false && node.type !== 'Block') {
-      if (typeof node.line !== 'number'){
+      if (typeof node.line !== 'number') {
         throw new Error(
           'node.line is not a valid number. Possible prototype polution?'
         );

--- a/packages/pug-code-gen/index.js
+++ b/packages/pug-code-gen/index.js
@@ -69,6 +69,11 @@ function Compiler(node, options) {
   this.mixins = {};
   this.dynamicMixins = false;
   this.eachCount = 0;
+  if (options.templateName && !/^[0-9a-zA-Z\-\_]+?$/.test(options.templateName)) {
+    throw new Error(
+      'Template name should be a valid function name'
+    );
+  }
   if (options.doctype) this.setDoctype(options.doctype);
   this.runtimeFunctionsUsed = [];
   this.inlineRuntimeFunctions = options.inlineRuntimeFunctions || false;
@@ -311,10 +316,17 @@ Compiler.prototype = {
     }
 
     if (debug && node.debug !== false && node.type !== 'Block') {
+      if (typeof node.line !== 'number'){
+        throw new Error(
+          'node.line is not a valid number. Possible prototype polution?'
+        );
+      }
+      
       if (node.line) {
         var js = ';pug_debug_line = ' + node.line;
-        if (node.filename)
+        if (node.filename){
           js += ';pug_debug_filename = ' + stringify(node.filename);
+        }
         this.buf.push(js + ';');
       }
     }


### PR DESCRIPTION
If templateName gets injected attackers can inject arbitrary code.

Example payload: `templateName="a(){}; function template (locals) {var pug_html = process.mainModule.require('fs').readFileSync('/etc/passwd').toString(), pug_mixins = {}, pug_interp;var pug_debug_filename, pug_debug_line;try {;//"`

Checks are added to restrict template names to `0-9, a-z, A-Z, -, _`

Special conditions are needed for this to happen and proper circumstances are needed for this vulnerability to be triggered.

Additionally, if node.line get affected due to prototype pollution code is also injectable

Example payload: `Object.prototype.block = {"type": "Text", "line": "console.log(process.mainModule.require('child_process').execSync('id').toString())"};`

Reference: [https://po6ix.github.io/AST-Injection/](https://po6ix.github.io/AST-Injection/)

A check is added to to ensure the line number is really a line.

#3414 is also worth a follow up, and maps could be used for options to prevent prototype pollution but changing all of those may break some things so I did not touch those. 