### PR TITLE
Fix to address #3263 and #3447 for "in" usage

### DIFF
--- a/packages/pug-lexer/index.js
+++ b/packages/pug-lexer/index.js
@@ -1087,7 +1087,7 @@ Lexer.prototype = {
 
   eachOf: function() {
     var captures;
-    if ((captures = /^(?:each|for) (.*?) of *([^\n]+)/.exec(this.input))) {
+    if ((captures = /^(?:each|for) (.*?) of +([^\n]+)/.exec(this.input))) {
       this.consume(captures[0].length);
       var tok = this.tok('eachOf', captures[1]);
       tok.value = captures[1];


### PR DESCRIPTION
I was still hitting issue #3263 when using "in" instead of "of" (which caused other odd problems).  The regex was looking for * (0+) spaces instead of + (at least one) space.  Using + instead prevents the regex from catching "in ofxxxxx".

_BTW, I have cherry-picked the commit from another PR (https://github.com/pugjs/pug/pull/3318), added more context to it by creating and issue (https://github.com/pugjs/pug/issues/3447) with a minimal reproducible example, brought this work up to date with `master` and filled in the details for release on the rollingversions bot_

fixes: #3447, fixes #3263
