### PR TITLE
Fix(lexer): prevent false positive matching of 'of' keyword in string…

### DIFF
--- a/packages/pug-lexer/index.js
+++ b/packages/pug-lexer/index.js
@@ -1087,7 +1087,7 @@ Lexer.prototype = {
 
   eachOf: function() {
     var captures;
-    if ((captures = /^(?:each|for) (.*?) of *([^\n]+)/.exec(this.input))) {
+    if ((captures = /^(?:each|for) +(\[[\w$, ]+\]|[a-zA-Z_$][\w$]*) +of +([^\n]+)/.exec(this.input))) {
       this.consume(captures[0].length);
       var tok = this.tok('eachOf', captures[1]);
       tok.value = captures[1];


### PR DESCRIPTION
… literals

The eachOf regex was incorrectly matching the word 'of' inside string values when parsing 'each...in' loops, causing syntax errors for valid code.

Example that previously failed:
  each link in ['Terms of service', 'Privacy policy', 'License']
    a= link

Changed the regex from /^(?:each|for) (.*?) of *([^\n]+)/ to require:
- Explicit whitespace around the 'of' keyword
- Valid variable patterns (identifier or [key, value] destructuring)

This ensures 'of' is recognized as a keyword only when used as such, not when it appears within string literals in the iterable expression.